### PR TITLE
Guard Clause for Null or WhiteSpace

### DIFF
--- a/src/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -1,0 +1,38 @@
+﻿using Ardalis.GuardClauses;
+using System;
+using Xunit;
+
+namespace GuardClauses.UnitTests
+{
+    public class GuardAgainstNullOrWhiteSpace
+    {
+        [Theory]
+        [InlineData("a")]
+        [InlineData("1")]
+        public void DoesNothingGivenNonEmptyStringValue(string nonEmptyString)
+        {
+            Guard.Against.NullOrWhiteSpace(nonEmptyString, "string");
+            Guard.Against.NullOrWhiteSpace(nonEmptyString, "aNumericString");
+        }
+
+        [Fact]
+        public void ThrowsGivenNullValue()
+        {
+            Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(null, "null"));
+        }
+
+        [Fact]
+        public void ThrowsGivenEmptyString()
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace("", "emptystring"));
+        }
+
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("   ")]
+        public void ThrowsGivenWhiteSpaceString(string whiteSpaceString)
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring"));
+        }
+    }
+}

--- a/src/GuardClauses.UnitTests/GuardClauses.UnitTests.csproj
+++ b/src/GuardClauses.UnitTests/GuardClauses.UnitTests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 
 namespace Ardalis.GuardClauses
 {
@@ -11,7 +12,7 @@ namespace Ardalis.GuardClauses
     public static class GuardClauseExtensions
     {
         /// <summary>
-        /// Throws an ArgumentNullException if input is null.
+        /// Throws an <see cref="ArgumentNullException" /> if <see cref="input" /> is null.
         /// </summary>
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
@@ -26,8 +27,8 @@ namespace Ardalis.GuardClauses
         }
 
         /// <summary>
-        /// Throws an ArgumentNullException if input is null.
-        /// Throws an ArgumentException if input is an empty string.
+        /// Throws an <see cref="ArgumentNullException" /> if <see cref="input" /> is null.
+        /// Throws an <see cref="ArgumentException" /> if <see cref="input" /> is an empty string.
         /// </summary>
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
@@ -44,7 +45,25 @@ namespace Ardalis.GuardClauses
         }
 
         /// <summary>
-        /// Throws an ArgumentOutOfRange if input is less than <see cref="rangeFrom"/> or greater than <see cref="rangeTo"/>
+        /// Throws an <see cref="ArgumentNullException" /> if <see cref="input" /> is null.
+        /// Throws an <see cref="ArgumentException" /> if <see cref="input" /> is an empty or white space string.
+        /// </summary>
+        /// <param name="guardClause"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        public static void NullOrWhiteSpace(this IGuardClause guardClause, string input, string parameterName)
+        {
+            Guard.Against.NullOrEmpty(input, parameterName);
+            if (Regex.IsMatch(input, @"\s"))
+            {
+                throw new ArgumentException($"Required input {parameterName} was empty.", parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <see cref="input" /> is less than <see cref="rangeFrom" /> or greater than <see cref="rangeTo" />.
         /// </summary>
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
@@ -53,8 +72,7 @@ namespace Ardalis.GuardClauses
         /// <param name="rangeTo"></param>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfRange(this IGuardClause guardClause, int input, string parameterName,
-            int rangeFrom, int rangeTo)
+        public static void OutOfRange(this IGuardClause guardClause, int input, string parameterName, int rangeFrom, int rangeTo)
         {
             if (rangeFrom > rangeTo)
             {


### PR DESCRIPTION
Same as `NullOrEmpty`, but also throws an `ArgumentException` if the string consists of nothing but whitespace characters.

Also includes:
* Updating XML comments to use `<see cref />` where possible
* Updating NuGet packages to latest version in the Unit Tests project.