### PR TITLE
Intelisense not showing any xml comments. XML documentation file is missing.

### DIFF
--- a/src/GuardClauses/GuardClauses.csproj
+++ b/src/GuardClauses/GuardClauses.csproj
@@ -21,6 +21,9 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\Ardalis.GuardClauses.xml</DocumentationFile>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
Quick change in the project properties to enable generation of XML documentation file. By default I put these files under "bin\$(Configuration)\", but it can be changed to any other location. By generating the xml file during the build, it would be included in the nuget package as well. The change won't break the build in the azure pipeline, and the package generated in the pipeline would contain the file too.

Note: By enabling the option, the compiler will produce a lot of warnings. The syntax in the comments has few errors. I will address that in a separate PR.