### PR TITLE
Apply Jet Brains Attribute Annonations to enforce better coding pract…

### DIFF
--- a/src/GuardClauses/Guard.cs
+++ b/src/GuardClauses/Guard.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace Ardalis.GuardClauses
 {
@@ -15,7 +16,7 @@ namespace Ardalis.GuardClauses
     /// <remarks>See http://www.weeklydevtips.com/004 on Guard Clauses</remarks>
     public class Guard : IGuardClause
     {
-        public static IGuardClause Against { get; } = new Guard();
+        [NotNull] public static IGuardClause Against { get; } = new Guard();
 
         private Guard() { }
     }

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 
 namespace Ardalis.GuardClauses

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
+using JetBrains.Annotations;
 
 namespace Ardalis.GuardClauses
 {
@@ -19,7 +21,7 @@ namespace Ardalis.GuardClauses
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentNullException"></exception>
-        public static void Null(this IGuardClause guardClause, object input, string parameterName)
+        public static void Null([NotNull] this IGuardClause guardClause, [NotNull] object input, [NotNull] string parameterName)
         {
             if (null == input)
             {
@@ -36,7 +38,7 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public static void NullOrEmpty(this IGuardClause guardClause, string input, string parameterName)
+        public static void NullOrEmpty([NotNull] this IGuardClause guardClause, [NotNull] string input, [NotNull] string parameterName)
         {
             Guard.Against.Null(input, parameterName);
             if (input == String.Empty)
@@ -54,7 +56,7 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public static void NullOrEmpty<T>(this IGuardClause guardClause, IEnumerable<T> input, string parameterName)
+        public static void NullOrEmpty<T>([NotNull] this IGuardClause guardClause, [NotNull] IEnumerable<T> input, [NotNull] string parameterName)
         {
             Guard.Against.Null(input, parameterName);
             if (!input.Any())
@@ -72,7 +74,7 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public static void NullOrWhiteSpace(this IGuardClause guardClause, string input, string parameterName)
+        public static void NullOrWhiteSpace([NotNull] this IGuardClause guardClause, [NotNull] string input, [NotNull] string parameterName)
         {
             Guard.Against.NullOrEmpty(input, parameterName);
             if (String.IsNullOrWhiteSpace(input))
@@ -91,8 +93,9 @@ namespace Ardalis.GuardClauses
         /// <param name="rangeTo"></param>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfRange(this IGuardClause guardClause, int input, string parameterName, int rangeFrom, int rangeTo)
+        public static void OutOfRange([NotNull] this IGuardClause guardClause, int input, [NotNull] string parameterName, int rangeFrom, int rangeTo)
         {
+            
             OutOfRange<int>(guardClause, input, parameterName, rangeFrom, rangeTo);
         }
 
@@ -106,7 +109,7 @@ namespace Ardalis.GuardClauses
         /// <param name="rangeTo"></param>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfRange(this IGuardClause guardClause, DateTime input, string parameterName, DateTime rangeFrom, DateTime rangeTo)
+        public static void OutOfRange([NotNull] this IGuardClause guardClause, DateTime input, [NotNull] string parameterName, DateTime rangeFrom, DateTime rangeTo)
         {
             OutOfRange<DateTime>(guardClause, input, parameterName, rangeFrom, rangeTo);
         }
@@ -118,7 +121,7 @@ namespace Ardalis.GuardClauses
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfSQLDateRange(this IGuardClause guardClause, DateTime input, string parameterName)
+        public static void OutOfSQLDateRange([NotNull] this IGuardClause guardClause, DateTime input, [NotNull] string parameterName)
         {
             // System.Data is unavailable in .NET Standard so we can't use SqlDateTime.
             const long sqlMinDateTicks = 552877920000000000;
@@ -177,7 +180,7 @@ namespace Ardalis.GuardClauses
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentException"></exception>
-        public static void Zero(this IGuardClause guardClause, int input, string parameterName)
+        public static void Zero([NotNull] this IGuardClause guardClause, int input, [NotNull] string parameterName)
         {
             Zero<int>(guardClause, input, parameterName);
         }
@@ -189,7 +192,7 @@ namespace Ardalis.GuardClauses
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentException"></exception>
-        public static void Zero(this IGuardClause guardClause, long input, string parameterName)
+        public static void Zero([NotNull] this IGuardClause guardClause, long input, [NotNull] string parameterName)
         {
             Zero<long>(guardClause, input, parameterName);
         }
@@ -201,7 +204,7 @@ namespace Ardalis.GuardClauses
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentException"></exception>
-        public static void Zero(this IGuardClause guardClause, decimal input, string parameterName)
+        public static void Zero([NotNull] this IGuardClause guardClause, decimal input, [NotNull] string parameterName)
         {
             Zero<decimal>(guardClause, input, parameterName);
         }
@@ -213,7 +216,7 @@ namespace Ardalis.GuardClauses
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentException"></exception>
-        public static void Zero(this IGuardClause guardClause, float input, string parameterName)
+        public static void Zero([NotNull] this IGuardClause guardClause, float input, [NotNull] string parameterName)
         {
             Zero<float>(guardClause, input, parameterName);
         }
@@ -225,7 +228,7 @@ namespace Ardalis.GuardClauses
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentException"></exception>
-        public static void Zero(this IGuardClause guardClause, double input, string parameterName)
+        public static void Zero([NotNull] this IGuardClause guardClause, double input, [NotNull] string parameterName)
         {
             Zero<double>(guardClause, input, parameterName);
         }
@@ -237,8 +240,9 @@ namespace Ardalis.GuardClauses
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentException"></exception>
-        private static void Zero<T>(this IGuardClause guardClause, T input, string parameterName)
+        private static void Zero<T>([NotNull] this IGuardClause guardClause, [NotNull] T input, [NotNull] string parameterName)
         {
+            if (input == null) throw new ArgumentNullException(nameof(input));
             if (EqualityComparer<T>.Default.Equals(input, default(T)))
             {
                 throw new ArgumentException($"Required input {parameterName} cannot be zero.", parameterName);
@@ -253,13 +257,11 @@ namespace Ardalis.GuardClauses
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfRange<T>(this IGuardClause guardClause, int input, string parameterName) where T : Enum
+        public static void OutOfRange<T>([NotNull] this IGuardClause guardClause, int input, [NotNull] string parameterName) where T : Enum
         {
-            if (!Enum.IsDefined(typeof(T), input))
-            {
-                string enumName = typeof(T).ToString();
-                throw new ArgumentOutOfRangeException(parameterName, $"Required input {parameterName} was not a valid enum value for {typeof(T).ToString()}.");
-            }
+            if (Enum.IsDefined(typeof(T), input)) return;
+            var enumName = typeof(T).ToString();
+            throw new ArgumentOutOfRangeException(parameterName, $"Required input {parameterName} was not a valid enum value for {typeof(T).ToString()}.");
         }
 
         /// <summary>
@@ -269,7 +271,7 @@ namespace Ardalis.GuardClauses
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
         /// <exception cref="ArgumentException"></exception>
-        public static void Default<T>(this IGuardClause guardClause, T input, string parameterName)
+        public static void Default<T>([NotNull] this IGuardClause guardClause, [NotNull] T input, [NotNull] string parameterName)
         {
             if (EqualityComparer<T>.Default.Equals(input, default(T)))
             {

--- a/src/GuardClauses/GuardClauses.csproj
+++ b/src/GuardClauses/GuardClauses.csproj
@@ -22,6 +22,7 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Apply Jet Brains Attribute Annotations to enforce better coding practices, it shows warning to consumers of the extension methods that "Possible null exception to entity marked as NotNull" and if used inside method, like seen twitter screen shots, Roslyn will not display warning that you have to check for null, as guard against that already exists.