### PR TITLE
Add out of range guards for short and decimal types

### DIFF
--- a/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
@@ -1,0 +1,37 @@
+﻿using Ardalis.GuardClauses;
+using System;
+using Xunit;
+
+namespace GuardClauses.UnitTests
+{
+    public class GuardAgainstOutOfRangeForDecimal
+    {
+        [Theory]
+        [InlineData(1.0, 1.0, 1.0)]
+        [InlineData(1.0, 1.0, 3.0)]
+        [InlineData(2.0, 1.0, 3.0)]
+        [InlineData(3.0, 1.0, 3.0)]
+        public void DoesNothingGivenInRangeValue(decimal input, decimal rangeFrom, decimal rangeTo)
+        {
+            Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
+        }
+
+        [Theory]
+        [InlineData(-1.0, 1.0, 3.0)]
+        [InlineData(0.0, 1.0, 3.0)]
+        [InlineData(4.0, 1.0, 3.0)]
+        public void ThrowsGivenOutOfRangeValue(decimal input, decimal rangeFrom, decimal rangeTo)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
+
+        [Theory]
+        [InlineData(-1.0, 3.0, 1.0)]
+        [InlineData(0.0, 3.0, 1.0)]
+        [InlineData(4.0, 3.0, 1.0)]
+        public void ThrowsGivenInvalidArgumentValue(decimal input, decimal rangeFrom, decimal rangeTo)
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
+    }
+}

--- a/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
@@ -1,0 +1,37 @@
+﻿using Ardalis.GuardClauses;
+using System;
+using Xunit;
+
+namespace GuardClauses.UnitTests
+{
+    public class GuardAgainstOutOfRangeForShort
+    {
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(1, 1, 3)]
+        [InlineData(2, 1, 3)]
+        [InlineData(3, 1, 3)]
+        public void DoesNothingGivenInRangeValue(short input, short rangeFrom, short rangeTo)
+        {
+            Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
+        }
+
+        [Theory]
+        [InlineData(-1, 1, 3)]
+        [InlineData(0, 1, 3)]
+        [InlineData(4, 1, 3)]
+        public void ThrowsGivenOutOfRangeValue(short input, short rangeFrom, short rangeTo)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
+
+        [Theory]
+        [InlineData(-1, 3, 1)]
+        [InlineData(0, 3, 1)]
+        [InlineData(4, 3, 1)]
+        public void ThrowsGivenInvalidArgumentValue(short input, short rangeFrom, short rangeTo)
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
+    }
+}

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace Ardalis.GuardClauses
 {
@@ -127,6 +125,34 @@ namespace Ardalis.GuardClauses
             const long sqlMaxDateTicks = 3155378975999970000;
 
             OutOfRange<DateTime>(guardClause, input, parameterName, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks));
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <see cref="input" /> is less than <see cref="rangeFrom" /> or greater than <see cref="rangeTo" />.
+        /// </summary>
+        /// <param name="guardClause"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        /// <param name="rangeFrom"></param>
+        /// <param name="rangeTo"></param>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public static void OutOfRange(this IGuardClause guardClause, decimal input, string parameterName, decimal rangeFrom, decimal rangeTo)
+        {
+            OutOfRange<decimal>(guardClause, input, parameterName, rangeFrom, rangeTo);
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <see cref="input" /> is less than <see cref="rangeFrom" /> or greater than <see cref="rangeTo" />.
+        /// </summary>
+        /// <param name="guardClause"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        /// <param name="rangeFrom"></param>
+        /// <param name="rangeTo"></param>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public static void OutOfRange(this IGuardClause guardClause, short input, string parameterName, short rangeFrom, short rangeTo)
+        {
+            OutOfRange<short>(guardClause, input, parameterName, rangeFrom, rangeTo);
         }
 
         private static void OutOfRange<T>(this IGuardClause guardClause, T input, string parameterName, T rangeFrom, T rangeTo)


### PR DESCRIPTION
#46 

Based on the above issue, I am opening a PR to add requested out of range guards for decimal and short types. I have provided test coverage for both extensions. Also removed usings from GuardClauseExtensions.cs that are no longer needed.