### PR TITLE
1.3.3 - Guard.Against.NegativeOrZero + Cleanup

### DIFF
--- a/src/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
@@ -1,0 +1,87 @@
+﻿using Ardalis.GuardClauses;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace GuardClauses.UnitTests
+{
+    public class GuardAgainstNegativeOrZero
+    {
+        [Fact]
+        public void DoesNothingGivenPositiveValue() 
+        {
+            Guard.Against.NegativeOrZero(1, "intPositive");
+            Guard.Against.NegativeOrZero(1L, "longPositive");
+            Guard.Against.NegativeOrZero(1.0M, "decimalPositive");
+            Guard.Against.NegativeOrZero(1.0f, "floatPositive");
+            Guard.Against.NegativeOrZero(1.0, "doublePositive");
+        }
+
+        [Fact]
+        public void ThrowsGivenZeroIntValue()
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0, "intZero"));
+        }
+
+        [Fact]
+        public void ThrowsGivenZeroLongValue()
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0L, "longZero"));
+        }
+
+        [Fact]
+        public void ThrowsGivenZeroDecimalValue()
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0M, "decimalZero"));
+        }
+
+        [Fact]
+        public void ThrowsGivenZeroFloatValue()
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0f, "floatZero"));
+        }
+
+        [Fact]
+        public void ThrowsGivenZeroDoubleValue()
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0.0, "doubleZero"));
+        }
+
+
+        [Fact]
+        public void ThrowsGivenNegativeIntValue()
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1, "intNegative"));
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-42, "intNegative"));
+        }
+
+        [Fact]
+        public void ThrowsGivenNegativeLongValue()
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1L, "longNegative"));
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-456L, "longNegative"));
+        }
+
+        [Fact]
+        public void ThrowsGivenNegativeDecimalValue()
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1M, "decimalNegative"));
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-567M, "decimalNegative"));
+        }
+
+        [Fact]
+        public void ThrowsGivenNegativeFloatValue()
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1f, "floatNegative"));
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-4567f, "floatNegative"));
+        }
+
+        [Fact]
+        public void ThrowsGivenNegativeDoubleValue()
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1.0, "doubleNegative"));
+            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-456.453, "doubleNegative"));
+        }
+    }
+}

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -6,7 +6,7 @@ using JetBrains.Annotations;
 namespace Ardalis.GuardClauses
 {
     /// <summary>
-    /// A collection of common guard clauses, implented as extensions.
+    /// A collection of common guard clauses, implemented as extensions.
     /// </summary>
     /// <example>
     /// Guard.Against.Null(input, nameof(input));
@@ -94,7 +94,6 @@ namespace Ardalis.GuardClauses
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         public static void OutOfRange([NotNull] this IGuardClause guardClause, int input, [NotNull] string parameterName, int rangeFrom, int rangeTo)
         {
-            
             OutOfRange<int>(guardClause, input, parameterName, rangeFrom, rangeTo);
         }
 
@@ -130,7 +129,7 @@ namespace Ardalis.GuardClauses
         }
 
         /// <summary>
-        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <see cref="input" /> is less than <see cref="rangeFrom" /> or greater than <see cref="rangeTo" />.
+        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input"/> is less than <paramref name="rangeFrom"/> or greater than <paramref name="rangeTo"/>.
         /// </summary>
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
@@ -144,7 +143,7 @@ namespace Ardalis.GuardClauses
         }
 
         /// <summary>
-        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <see cref="input" /> is less than <see cref="rangeFrom" /> or greater than <see cref="rangeTo" />.
+        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input"/> is less than <paramref name="rangeFrom"/> or greater than <paramref name="rangeTo"/>.
         /// </summary>
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
@@ -157,6 +156,15 @@ namespace Ardalis.GuardClauses
             OutOfRange<short>(guardClause, input, parameterName, rangeFrom, rangeTo);
         }
 
+        /// <summary>
+        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input"/> is less than <paramref name="rangeFrom"/> or greater than <paramref name="rangeTo"/>.
+        /// </summary>
+        /// <param name="guardClause"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        /// <param name="rangeFrom"></param>
+        /// <param name="rangeTo"></param>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
         private static void OutOfRange<T>(this IGuardClause guardClause, T input, string parameterName, T rangeFrom, T rangeTo)
         {
             Comparer<T> comparer = Comparer<T>.Default;
@@ -247,9 +255,9 @@ namespace Ardalis.GuardClauses
                 throw new ArgumentException($"Required input {parameterName} cannot be zero.", parameterName);
             }
         }
-        
+
         /// <summary>
-        /// Throws an <see cref="ArgumentException" /> if <see cref="input" /> is negative.
+        /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
         /// </summary>
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
@@ -259,9 +267,9 @@ namespace Ardalis.GuardClauses
         {
             Negative<int>(guardClause, input, parameterName);
         }
-        
+
         /// <summary>
-        /// Throws an <see cref="ArgumentException" /> if <see cref="input" /> is negative.
+        /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
         /// </summary>
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
@@ -271,9 +279,9 @@ namespace Ardalis.GuardClauses
         {
             Negative<long>(guardClause, input, parameterName);
         }
-        
+
         /// <summary>
-        /// Throws an <see cref="ArgumentException" /> if <see cref="input" /> is negative.
+        /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
         /// </summary>
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
@@ -283,9 +291,9 @@ namespace Ardalis.GuardClauses
         {
             Negative<decimal>(guardClause, input, parameterName);
         }
-        
+
         /// <summary>
-        /// Throws an <see cref="ArgumentException" /> if <see cref="input" /> is negative.
+        /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
         /// </summary>
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
@@ -295,9 +303,9 @@ namespace Ardalis.GuardClauses
         {
             Negative<float>(guardClause, input, parameterName);
         }
-        
+
         /// <summary>
-        /// Throws an <see cref="ArgumentException" /> if <see cref="input" /> is negative.
+        /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
         /// </summary>
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
@@ -309,7 +317,7 @@ namespace Ardalis.GuardClauses
         }
         
         /// <summary>
-        /// Throws an <see cref="ArgumentException" /> if <see cref="input" /> is negative.
+        /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
         /// </summary>
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
@@ -325,7 +333,78 @@ namespace Ardalis.GuardClauses
         }
 
         /// <summary>
-        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input" /> is not a valid enum value.
+        /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero.
+        /// </summary>
+        /// <param name="guardClause"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        public static void NegativeOrZero([NotNull] this IGuardClause guardClause, int input, [NotNull] string parameterName)
+        {
+            NegativeOrZero<int>(guardClause ,input, parameterName);
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero.
+        /// </summary>
+        /// <param name="guardClause"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        public static void NegativeOrZero([NotNull] this IGuardClause guardClause, long input, [NotNull] string parameterName)
+        {
+            NegativeOrZero<long>(guardClause, input, parameterName);
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero.
+        /// </summary>
+        /// <param name="guardClause"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        public static void NegativeOrZero([NotNull] this IGuardClause guardClause, decimal input, [NotNull] string parameterName)
+        {
+            NegativeOrZero<decimal>(guardClause, input, parameterName);
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero.
+        /// </summary>
+        /// <param name="guardClause"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        public static void NegativeOrZero([NotNull] this IGuardClause guardClause, float input, [NotNull] string parameterName)
+        {
+            NegativeOrZero<float>(guardClause, input, parameterName);
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero.
+        /// </summary>
+        /// <param name="guardClause"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        public static void NegativeOrZero([NotNull] this IGuardClause guardClause, double input, [NotNull] string parameterName)
+        {
+            NegativeOrZero<double>(guardClause, input, parameterName);
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero. 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="guardClause"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        private static void NegativeOrZero<T>([NotNull] this IGuardClause guardClause, [NotNull] T input, [NotNull] string parameterName) where T : IComparable
+        {
+            if (input == null) throw new ArgumentNullException(nameof(input));
+            if (input.CompareTo(default(T)) <= 0)
+            {
+                throw new ArgumentException($"Required input {parameterName} cannot be zero or negative.", parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input"/> is not a valid enum value.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="guardClause"></param>
@@ -335,12 +414,11 @@ namespace Ardalis.GuardClauses
         public static void OutOfRange<T>([NotNull] this IGuardClause guardClause, int input, [NotNull] string parameterName) where T : Enum
         {
             if (Enum.IsDefined(typeof(T), input)) return;
-            var enumName = typeof(T).ToString();
-            throw new ArgumentOutOfRangeException(parameterName, $"Required input {parameterName} was not a valid enum value for {typeof(T).ToString()}.");
+            throw new ArgumentOutOfRangeException(parameterName, $"Required input {parameterName} was not a valid enum value for {typeof(T)}.");
         }
-        
+
         /// <summary>
-        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <see cref="input" /> is not a valid enum value.
+        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input"/> is not a valid enum value.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="guardClause"></param>

--- a/src/GuardClauses/GuardClauses.csproj
+++ b/src/GuardClauses/GuardClauses.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/ardalis/guardclauses</RepositoryUrl>
     <PackageTags>guard clause clauses assert assertion</PackageTags>
     <PackageReleaseNotes>Adding NotNull attribute and XML comment support.</PackageReleaseNotes>
-    <Version>1.3.2</Version>
+    <Version>1.3.3</Version>
     <AssemblyName>Ardalis.GuardClauses</AssemblyName>
     <PackageIconUrl>https://user-images.githubusercontent.com/782127/52231271-7d561400-2887-11e9-9ca5-648259e60b37.png</PackageIconUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
- Guard.Against.NegativeOrZero implemented
- Guard.Against.NegativeOrZero UnitTests added
- Fixed typo in Class Level Xml Comment.
- Changed usage of cref to paramref in xml comments, multiple locations to ensure correct parameter highlighting.
- Removed unused enumName variable from OutOfRange method.