### PR TITLE
Guard and return in single statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@ If you like or are using this project please give it a star. Thanks!
 
         // process order here
     }
+
+    // OR
+
+    public class Order
+    {
+        private string _name;
+        private int _quantity;
+        private long _max;
+        private decimal _unitPrice;
+        private DateTime _dateCreated;
+
+        public Order(string name, int quantity, long max, decimal unitPrice, DateTime dateCreated)
+        {
+            _name = Guard.Against.NullOrWhiteSpace(name, nameof(name));
+            _quantity = Guard.Against.NegativeOrZero(quantity, nameof(quantity));
+            _max = Guard.Against.Zero(max, nameof(max));
+            _unitPrice = Guard.Against.Negative(unitPrice, nameof(unitPrice));
+            _dateCreated = Guard.Against.OutOfSQLDateRange(dateCreated, nameof(dateCreated));
+        }
+    }
 ```
 
 ## Supported Guard Clauses

--- a/src/GuardClauses.UnitTests/GuardAgainstDefault.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstDefault.cs
@@ -1,5 +1,6 @@
 ﻿using Ardalis.GuardClauses;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace GuardClauses.UnitTests
@@ -24,6 +25,29 @@ namespace GuardClauses.UnitTests
             Assert.Throws<ArgumentException>("guid", () => Guard.Against.Default(default(Guid), "guid"));
             Assert.Throws<ArgumentException>("datetime", () => Guard.Against.Default(default(DateTime), "datetime"));
             Assert.Throws<ArgumentException>("object", () => Guard.Against.Default(default(object), "object"));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNonDefaultTestVectors))]
+        public void ReturnsExpectedValueWhenGivenNonDefaultValue(object input, string name, object expected)
+        {
+            var actual = Guard.Against.Default(input, name);
+            Assert.Equal(expected, actual);
+        }
+
+        public static IEnumerable<object[]> GetNonDefaultTestVectors()
+        {
+            yield return new object[] {"", "string", ""};
+            yield return new object[] {1, "int", 1};
+            
+            var guid = Guid.NewGuid();
+            yield return new object[] {guid, "guid", guid};
+
+            var now = DateTime.Now;
+            yield return new object[] {now, "now", now};
+
+            var obj = new Object();
+            yield return new object[] {obj, "obj", obj};
         }
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstNegative.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstNegative.cs
@@ -55,5 +55,40 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0, "negative"));
         }
+
+        [Fact]
+        public void ReturnsExpectedValueGivenNonNegativeIntValue()
+        {
+            Assert.Equal(0, Guard.Against.Negative(0, "intZero"));
+            Assert.Equal(1, Guard.Against.Negative(1, "intOne"));
+        }
+
+        [Fact]
+        public void ReturnsExpectedValueGivenNonNegativeLongValue()
+        {
+            Assert.Equal(0L, Guard.Against.Negative(0L, "longZero"));
+            Assert.Equal(1L, Guard.Against.Negative(1L, "longOne"));
+        }
+
+        [Fact]
+        public void ReturnsExpectedValueGivenNonNegativeDecimalValue()
+        {
+            Assert.Equal(0.0M, Guard.Against.Negative(0.0M, "decimalZero"));
+            Assert.Equal(1.0M, Guard.Against.Negative(1.0M, "decimalOne"));
+        }
+
+        [Fact]
+        public void ReturnsExpectedValueGivenNonNegativeFloatValue()
+        {
+            Assert.Equal(0.0f, Guard.Against.Negative(0.0f, "floatZero"));
+            Assert.Equal(1.0f, Guard.Against.Negative(1.0f, "floatOne"));
+        }
+
+        [Fact]
+        public void ReturnsExpectedValueGivenNonNegativeDoubleValue()
+        {
+            Assert.Equal(0.0, Guard.Against.Negative(0.0, "doubleZero"));
+            Assert.Equal(1.0, Guard.Against.Negative(1.0, "doubleOne"));
+        }
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
@@ -83,5 +83,15 @@ namespace GuardClauses.UnitTests
             Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1.0, "doubleNegative"));
             Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-456.453, "doubleNegative"));
         }
+
+        [Fact]
+        public void ReturnsExpectedValueWhenGivenPositiveValue()
+        {
+            Assert.Equal(1, Guard.Against.NegativeOrZero(1, "intPositive"));
+            Assert.Equal(1L, Guard.Against.NegativeOrZero(1L, "longPositive"));
+            Assert.Equal(1.0M, Guard.Against.NegativeOrZero(1.0M, "decimalPositive"));
+            Assert.Equal(1.0f, Guard.Against.NegativeOrZero(1.0f, "floatPositive"));
+            Assert.Equal(1.0, Guard.Against.NegativeOrZero(1.0, "doublePositive"));
+        }
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstNull.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstNull.cs
@@ -21,5 +21,21 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(null, "null"));
         }
+
+        [Fact]
+        public void ReturnsExpectedValueWhenGivenNonNullValue()
+        {
+            Assert.Equal("", Guard.Against.Null("", "string"));
+            Assert.Equal(1, Guard.Against.Null(1, "int"));
+
+            var guid = Guid.Empty;
+            Assert.Equal(guid, Guard.Against.Null(guid, "guid"));
+            
+            var now = DateTime.Now;
+            Assert.Equal(now, Guard.Against.Null(now, "datetime"));
+
+            var obj = new Object();
+            Assert.Equal(obj, Guard.Against.Null(obj, "object"));
+        }
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
@@ -38,5 +38,18 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Enumerable.Empty<string>(), "emptyStringEnumerable"));
         }
+
+        [Fact]
+        public void ReturnsExpectedValueWhenGivenValidValue()
+        {
+            Assert.Equal("a", Guard.Against.NullOrEmpty("a", "string"));
+            Assert.Equal("1", Guard.Against.NullOrEmpty("1", "aNumericString"));
+
+            var collection1 = new[] {"foo", "bar"};
+            Assert.Equal(collection1, Guard.Against.NullOrEmpty(collection1, "stringArray"));
+
+            var collection2 = new[] {1, 2};
+            Assert.Equal(collection2, Guard.Against.NullOrEmpty(collection2, "intArray"));
+        }
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -37,5 +37,17 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring"));
         }
+
+        [Theory]
+        [InlineData("a", "a")]
+        [InlineData("1", "1")]
+        [InlineData("some text", "some text")]
+        [InlineData(" leading whitespace", " leading whitespace")]
+        [InlineData("trailing whitespace ", "trailing whitespace ")]
+        public void ReturnsExpectedValueGivenNonEmptyStringValue(string nonEmptyString, string expected)
+        {
+            Assert.Equal(expected, Guard.Against.NullOrWhiteSpace(nonEmptyString, "string"));
+            Assert.Equal(expected, Guard.Against.NullOrWhiteSpace(nonEmptyString, "aNumericString"));
+        }
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
@@ -40,5 +40,21 @@ namespace GuardClauses.UnitTests
             DateTime rangeTo = input.AddSeconds(rangeToOffset);
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(DateTime.Now, "index", rangeFrom, rangeTo));
         }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(0, 3)]
+        [InlineData(-1, 1)]
+        [InlineData(-1, 0)]
+        public void ReturnsExpectedValueGivenInRangeValue(int rangeFromOffset, int rangeToOffset)
+        {
+            DateTime input = DateTime.Now;
+            DateTime expected = input;
+            DateTime rangeFrom = input.AddSeconds(rangeFromOffset);
+            DateTime rangeTo = input.AddSeconds(rangeToOffset);
+            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
+
+
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
@@ -33,5 +33,15 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
         }
+
+        [Theory]
+        [InlineData(1.0, 0.0, 1.0, 1.0)]
+        [InlineData(1.0, 0.0, 3.0, 1.0)]
+        [InlineData(2.0, 1.0, 3.0, 2.0)]
+        [InlineData(3.0, 3.0, 3.0, 3.0)]
+        public void ReturnsExpectedValueGivenInRangeValue(decimal input, decimal rangeFrom, decimal rangeTo, decimal expected)
+        {
+            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
@@ -33,5 +33,15 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
         }
+
+        [Theory]
+        [InlineData(1.0, 0.0, 1.0, 1.0)]
+        [InlineData(1.0, 0.0, 3.0, 1.0)]
+        [InlineData(2.0, 1.0, 3.0, 2.0)]
+        [InlineData(3.0, 3.0, 3.0, 3.0)]
+        public void ReturnsExpectedValueGivenInRangeValue(double input, double rangeFrom, double rangeTo, double expected)
+        {
+            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
@@ -49,6 +49,32 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(enumValue, nameof(enumValue)));
         }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        public void ReturnsExpectedValueGivenInRangeValue(int enumValue)
+        {
+            var expected = enumValue;
+            Assert.Equal(expected, Guard.Against.OutOfRange<TestEnum>(enumValue, nameof(enumValue)));
+        }
+
+        [Theory]
+        [InlineData(TestEnum.Budgie)]
+        [InlineData(TestEnum.Cat)]
+        [InlineData(TestEnum.Dog)]
+        [InlineData(TestEnum.Fish)]
+        [InlineData(TestEnum.Frog)]
+        [InlineData(TestEnum.Penguin)]
+        public void ReturnsExpectedValueGivenInRangeEnum(TestEnum enumValue)
+        {
+            var expected = enumValue;
+            Assert.Equal(expected, Guard.Against.OutOfRange(enumValue, nameof(enumValue)));
+        }
         
     }
 

--- a/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
@@ -33,5 +33,15 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
         }
+
+        [Theory]
+        [InlineData(1.0, 1.0, 1.0, 1.0)]
+        [InlineData(1.0, 1.0, 3.0, 1.0)]
+        [InlineData(2.0, 1.0, 3.0, 2.0)]
+        [InlineData(3.0, 1.0, 3.0, 3.0)]
+        public void ReturnsExpectedValueGivenInRangeValue(float input, float rangeFrom, float rangeTo, float expected)
+        {
+            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
@@ -33,5 +33,15 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
         }
+
+        [Theory]
+        [InlineData(1, 1, 1, 1)]
+        [InlineData(1, 1, 3, 1)]
+        [InlineData(2, 1, 3, 2)]
+        [InlineData(3, 1, 3, 3)]
+        public void ReturnsExpectedValueGivenInRangeValue(int input, int rangeFrom, int rangeTo, int expected)
+        {
+            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
@@ -33,5 +33,15 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
         }
+
+        [Theory]
+        [InlineData(1, 1, 1, 1)]
+        [InlineData(1, 1, 3, 1)]
+        [InlineData(2, 1, 3, 2)]
+        [InlineData(3, 1, 3, 3)]
+        public void ReturnsExpectedValueGivenInRangeValue(short input, short rangeFrom, short rangeTo, short expected)
+        {
+            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
@@ -1,5 +1,7 @@
 ﻿using Ardalis.GuardClauses;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Data.SqlTypes;
 using Xunit;
 
@@ -57,6 +59,28 @@ namespace GuardClauses.UnitTests
             DateTime date = SqlDateTime.MaxValue.Value.AddSeconds(-offsetInSeconds);
 
             Guard.Against.OutOfSQLDateRange(date, nameof(date));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetSqlDateTimeTestVectors))]
+        public void ReturnsExpectedValueWhenGivenValidSqlDateTime(DateTime input, string name, DateTime expected)
+        {
+            Assert.Equal(expected, Guard.Against.OutOfSQLDateRange(input, name));
+        }
+
+        public static IEnumerable<object[]> GetSqlDateTimeTestVectors()
+        {
+            var now = DateTime.Now;
+            var utc = DateTime.UtcNow;
+            var yesterday = DateTime.Now.AddDays(-1);
+            var min = SqlDateTime.MinValue.Value;
+            var max = SqlDateTime.MaxValue.Value;
+
+            yield return new object[] {now, "now", now};
+            yield return new object[] {utc, "utc", utc};
+            yield return new object[] {yesterday, "yesterday", yesterday};
+            yield return new object[] {min, "min", min};
+            yield return new object[] {max, "max", max};
         }
     }
 }

--- a/src/GuardClauses.UnitTests/GuardAgainstZero.cs
+++ b/src/GuardClauses.UnitTests/GuardAgainstZero.cs
@@ -92,5 +92,21 @@ namespace GuardClauses.UnitTests
             Assert.Throws<ArgumentException>(() => Guard.Against.Zero(decimal.Zero, "zero"));
         }
 
+        [Fact]
+        public void ReturnsExpectedValueWhenGivenNonZeroValue()
+        {
+            Assert.Equal(-1, Guard.Against.Zero(-1, "minusOne"));
+            Assert.Equal(1, Guard.Against.Zero(1, "plusOne"));
+            Assert.Equal(int.MinValue, Guard.Against.Zero(int.MinValue, "int.MinValue"));
+            Assert.Equal(int.MaxValue, Guard.Against.Zero(int.MaxValue, "int.MaxValue"));
+            Assert.Equal(long.MinValue, Guard.Against.Zero(long.MinValue, "long.MinValue"));
+            Assert.Equal(long.MaxValue, Guard.Against.Zero(long.MaxValue, "long.MaxValue"));
+            Assert.Equal(decimal.MinValue, Guard.Against.Zero(decimal.MinValue, "decimal.MinValue"));
+            Assert.Equal(decimal.MaxValue, Guard.Against.Zero(decimal.MaxValue, "decimal.MaxValue"));
+            Assert.Equal(float.MinValue, Guard.Against.Zero(float.MinValue, "float.MinValue"));
+            Assert.Equal(float.MaxValue, Guard.Against.Zero(float.MaxValue, "float.MaxValue"));
+            Assert.Equal(double.MinValue, Guard.Against.Zero(double.MinValue, "double.MinValue"));
+            Assert.Equal(double.MaxValue, Guard.Against.Zero(double.MaxValue, "double.MaxValue"));
+        }
     }
 }

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -20,13 +20,16 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not null.</returns>
         /// <exception cref="ArgumentNullException"></exception>
-        public static void Null([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] object? input, [JetBrainsNotNull] string parameterName)
+        public static object Null([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] object? input, [JetBrainsNotNull] string parameterName)
         {
             if (null == input)
             {
                 throw new ArgumentNullException(parameterName);
             }
+
+            return input;
         }
 
         /// <summary>
@@ -36,15 +39,18 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not an empty string or null.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public static void NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input, [JetBrainsNotNull] string parameterName)
+        public static string NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input, [JetBrainsNotNull] string parameterName)
         {
             Guard.Against.Null(input, parameterName);
             if (input == String.Empty)
             {
                 throw new ArgumentException($"Required input {parameterName} was empty.", parameterName);
             }
+
+            return input;
         }
 
         /// <summary>
@@ -54,15 +60,18 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not an empty enumerable or null.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public static void NullOrEmpty<T>([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] IEnumerable<T>? input, [JetBrainsNotNull] string parameterName)
+        public static IEnumerable<T> NullOrEmpty<T>([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] IEnumerable<T>? input, [JetBrainsNotNull] string parameterName)
         {
             Guard.Against.Null(input, parameterName);
             if (!input.Any())
             {
                 throw new ArgumentException($"Required input {parameterName} was empty.", parameterName);
             }
+
+            return input;
         }
 
         /// <summary>
@@ -72,15 +81,18 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not an empty or whitespace string.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public static void NullOrWhiteSpace([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input, [JetBrainsNotNull] string parameterName)
+        public static string NullOrWhiteSpace([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input, [JetBrainsNotNull] string parameterName)
         {
             Guard.Against.NullOrEmpty(input, parameterName);
             if (String.IsNullOrWhiteSpace(input))
             {
                 throw new ArgumentException($"Required input {parameterName} was empty.", parameterName);
             }
+
+            return input;
         }
 
         /// <summary>
@@ -91,11 +103,12 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <returns><paramref name="input" /> if the value is inside the given range.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName, int rangeFrom, int rangeTo)
+        public static int OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName, int rangeFrom, int rangeTo)
         {
-            OutOfRange<int>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<int>(guardClause, input, parameterName, rangeFrom, rangeTo);
         }
 
         /// <summary>
@@ -106,27 +119,29 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <returns><paramref name="input" /> if the value is inside the given range.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, DateTime input, [JetBrainsNotNull] string parameterName, DateTime rangeFrom, DateTime rangeTo)
+        public static DateTime OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, DateTime input, [JetBrainsNotNull] string parameterName, DateTime rangeFrom, DateTime rangeTo)
         {
-            OutOfRange<DateTime>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<DateTime>(guardClause, input, parameterName, rangeFrom, rangeTo);
         }
 
         /// <summary>
-        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input" /> is not in the range of valid SqlDateTIme /> values.
+        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input" /> is not in the range of valid SqlDateTime values.
         /// </summary>
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfSQLDateRange([JetBrainsNotNull] this IGuardClause guardClause, DateTime input, [JetBrainsNotNull] string parameterName)
+        public static DateTime OutOfSQLDateRange([JetBrainsNotNull] this IGuardClause guardClause, DateTime input, [JetBrainsNotNull] string parameterName)
         {
             // System.Data is unavailable in .NET Standard so we can't use SqlDateTime.
             const long sqlMinDateTicks = 552877920000000000;
             const long sqlMaxDateTicks = 3155378975999970000;
 
-            OutOfRange<DateTime>(guardClause, input, parameterName, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks));
+            return OutOfRange<DateTime>(guardClause, input, parameterName, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks));
         }
 
         /// <summary>
@@ -137,10 +152,11 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfRange(this IGuardClause guardClause, decimal input, string parameterName, decimal rangeFrom, decimal rangeTo)
+        public static decimal OutOfRange(this IGuardClause guardClause, decimal input, string parameterName, decimal rangeFrom, decimal rangeTo)
         {
-            OutOfRange<decimal>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<decimal>(guardClause, input, parameterName, rangeFrom, rangeTo);
         }
 
         /// <summary>
@@ -151,10 +167,11 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfRange(this IGuardClause guardClause, short input, string parameterName, short rangeFrom, short rangeTo)
+        public static short OutOfRange(this IGuardClause guardClause, short input, string parameterName, short rangeFrom, short rangeTo)
         {
-            OutOfRange<short>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<short>(guardClause, input, parameterName, rangeFrom, rangeTo);
         }
 
         /// <summary>
@@ -165,10 +182,11 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfRange(this IGuardClause guardClause, double input, string parameterName, double rangeFrom, double rangeTo)
+        public static double OutOfRange(this IGuardClause guardClause, double input, string parameterName, double rangeFrom, double rangeTo)
         {
-            OutOfRange<double>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<double>(guardClause, input, parameterName, rangeFrom, rangeTo);
         }
 
         /// <summary>
@@ -179,10 +197,11 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfRange(this IGuardClause guardClause, float input, string parameterName, float rangeFrom, float rangeTo)
+        public static float OutOfRange(this IGuardClause guardClause, float input, string parameterName, float rangeFrom, float rangeTo)
         {
-            OutOfRange<float>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<float>(guardClause, input, parameterName, rangeFrom, rangeTo);
         }
 
         /// <summary>
@@ -193,8 +212,9 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        private static void OutOfRange<T>(this IGuardClause guardClause, T input, string parameterName, T rangeFrom, T rangeTo)
+        private static T OutOfRange<T>(this IGuardClause guardClause, T input, string parameterName, T rangeFrom, T rangeTo)
         {
             Comparer<T> comparer = Comparer<T>.Default;
 
@@ -207,6 +227,8 @@ namespace Ardalis.GuardClauses
             {
                 throw new ArgumentOutOfRangeException(parameterName, $"Input {parameterName} was out of range");
             }
+
+            return input;
         }
 
         /// <summary>
@@ -215,10 +237,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static void Zero([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName)
+        public static int Zero([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName)
         {
-            Zero<int>(guardClause, input, parameterName);
+            return Zero<int>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -227,10 +250,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static void Zero([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull] string parameterName)
+        public static long Zero([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull] string parameterName)
         {
-            Zero<long>(guardClause, input, parameterName);
+            return Zero<long>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -239,10 +263,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static void Zero([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull] string parameterName)
+        public static decimal Zero([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull] string parameterName)
         {
-            Zero<decimal>(guardClause, input, parameterName);
+            return Zero<decimal>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -251,10 +276,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static void Zero([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull] string parameterName)
+        public static float Zero([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull] string parameterName)
         {
-            Zero<float>(guardClause, input, parameterName);
+            return Zero<float>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -263,10 +289,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static void Zero([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull] string parameterName)
+        public static double Zero([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull] string parameterName)
         {
-            Zero<double>(guardClause, input, parameterName);
+            return Zero<double>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -275,13 +302,16 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        private static void Zero<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName) where T : struct
+        private static T Zero<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName) where T : struct
         {
             if (EqualityComparer<T>.Default.Equals(input, default(T)))
             {
                 throw new ArgumentException($"Required input {parameterName} cannot be zero.", parameterName);
             }
+
+            return input;
         }
 
         /// <summary>
@@ -290,10 +320,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static void Negative([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName)
+        public static int Negative([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName)
         {
-            Negative<int>(guardClause, input, parameterName);
+            return Negative<int>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -302,10 +333,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static void Negative([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull] string parameterName)
+        public static long Negative([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull] string parameterName)
         {
-            Negative<long>(guardClause, input, parameterName);
+            return Negative<long>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -314,10 +346,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static void Negative([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull] string parameterName)
+        public static decimal Negative([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull] string parameterName)
         {
-            Negative<decimal>(guardClause, input, parameterName);
+            return Negative<decimal>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -326,10 +359,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static void Negative([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull] string parameterName)
+        public static float Negative([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull] string parameterName)
         {
-            Negative<float>(guardClause, input, parameterName);
+            return Negative<float>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -338,10 +372,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static void Negative([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull] string parameterName)
+        public static double Negative([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull] string parameterName)
         {
-            Negative<double>(guardClause, input, parameterName);
+            return Negative<double>(guardClause, input, parameterName);
         }
         
         /// <summary>
@@ -350,13 +385,16 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        private static void Negative<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName) where T : struct, IComparable
+        private static T Negative<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName) where T : struct, IComparable
         {
             if (input.CompareTo(default(T)) < 0)
             {
                 throw new ArgumentException($"Required input {parameterName} cannot be negative.", parameterName);
             }
+
+            return input;
         }
 
         /// <summary>
@@ -365,9 +403,10 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
-        public static void NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName)
+        /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+        public static int NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName)
         {
-            NegativeOrZero<int>(guardClause ,input, parameterName);
+            return NegativeOrZero<int>(guardClause ,input, parameterName);
         }
 
         /// <summary>
@@ -376,9 +415,10 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
-        public static void NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull] string parameterName)
+        /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+        public static long NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull] string parameterName)
         {
-            NegativeOrZero<long>(guardClause, input, parameterName);
+            return NegativeOrZero<long>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -387,9 +427,10 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
-        public static void NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull] string parameterName)
+        /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+        public static decimal NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull] string parameterName)
         {
-            NegativeOrZero<decimal>(guardClause, input, parameterName);
+            return NegativeOrZero<decimal>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -398,9 +439,10 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
-        public static void NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull] string parameterName)
+        /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+        public static float NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull] string parameterName)
         {
-            NegativeOrZero<float>(guardClause, input, parameterName);
+            return NegativeOrZero<float>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -409,9 +451,10 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
-        public static void NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull] string parameterName)
+        /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+        public static double NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull] string parameterName)
         {
-            NegativeOrZero<double>(guardClause, input, parameterName);
+            return NegativeOrZero<double>(guardClause, input, parameterName);
         }
 
         /// <summary>
@@ -421,12 +464,15 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
-        private static void NegativeOrZero<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName) where T : struct, IComparable
+        /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+        private static T NegativeOrZero<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName) where T : struct, IComparable
         {
             if (input.CompareTo(default(T)) <= 0)
             {
                 throw new ArgumentException($"Required input {parameterName} cannot be zero or negative.", parameterName);
             }
+
+            return input;
         }
 
         /// <summary>
@@ -436,27 +482,35 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName) where T : struct, Enum
-        {
-            if (Enum.IsDefined(typeof(T), input)) return;
-            throw new ArgumentOutOfRangeException(parameterName, $"Required input {parameterName} was not a valid enum value for {typeof(T)}.");
-        }
-
-        /// <summary>
-        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input"/> is not a valid enum value.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="guardClause"></param>
-        /// <param name="input"></param>
-        /// <param name="parameterName"></param>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void OutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName) where T : struct, Enum
+        public static int OutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName) where T : struct, Enum
         {
             if (!Enum.IsDefined(typeof(T), input))
             {
                 throw new ArgumentOutOfRangeException(parameterName, $"Required input {parameterName} was not a valid enum value for {typeof(T)}.");
             }
+
+            return input;
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input"/> is not a valid enum value.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="guardClause"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not out of range.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public static T OutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName) where T : struct, Enum
+        {
+            if (!Enum.IsDefined(typeof(T), input))
+            {
+                throw new ArgumentOutOfRangeException(parameterName, $"Required input {parameterName} was not a valid enum value for {typeof(T)}.");
+            }
+
+            return input;
         }
 
         /// <summary>
@@ -465,13 +519,16 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not default for that type.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static void Default<T>([JetBrainsNotNull] this IGuardClause guardClause, [AllowNull, NotNull, JetBrainsNotNull] T input, [JetBrainsNotNull] string parameterName)
+        public static T Default<T>([JetBrainsNotNull] this IGuardClause guardClause, [AllowNull, NotNull, JetBrainsNotNull] T input, [JetBrainsNotNull] string parameterName)
         {
             if (EqualityComparer<T>.Default.Equals(input, default(T)!))
             {
                 throw new ArgumentException($"Parameter [{parameterName}] is default value for type {typeof(T).Name}", parameterName);
             }
+
+            return input;
         }
     }
 }


### PR DESCRIPTION
Modified all guard method signatures to return the input value if the null/empty/default etc validation checks pass.
This enables a more fluent interface with usage now being two-fold:
```c#
// case 1 (previously supported usage):
public void ProcessOrder(Order order)
{
    	Guard.Against.Null(order, nameof(order));

        // process order here
}

// case 2 (added functionality):
public class Order
{
        private string _name;
        private int _quantity;
        private long _max;
        private decimal _unitPrice;
        private DateTime _dateCreated;

        public Order(string name, int quantity, long max, decimal unitPrice, DateTime dateCreated)
        {
            _name = Guard.Against.NullOrWhiteSpace(name, nameof(name));
            _quantity = Guard.Against.NegativeOrZero(quantity, nameof(quantity));
            _max = Guard.Against.Zero(max, nameof(max));
            _unitPrice = Guard.Against.Negative(unitPrice, nameof(unitPrice));
            _dateCreated = Guard.Against.OutOfSQLDateRange(dateCreated, nameof(dateCreated));
        }
}
```

Does not break existing usages of these methods, just adds the ability to check and assign in a single statement (if desired).

Updated the readme and added tests for all method signatures that were changed.
Open to discussion, feedback etc.