### PR TITLE
Adding netstandard2.0 as a target

### DIFF
--- a/src/GuardClauses/GuardClauses.csproj
+++ b/src/GuardClauses/GuardClauses.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net40</TargetFrameworks>
     <PackageId>Ardalis.GuardClauses</PackageId>
     <Title>Ardalis.GuardClauses</Title>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Currently we have to accept several extra dependencies into our netcoreapp3.0 project in order to reference these. Adding this build target should eliminate that.