### PR TITLE
Modify OutOfRange to include the parameter name when InvalidEnumArgumentException is thrown.

### DIFF
--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -510,7 +510,7 @@ namespace Ardalis.GuardClauses
         {
             if (!Enum.IsDefined(typeof(T), input))
             {
-                throw new InvalidEnumArgumentException($"Required input {parameterName} was not a valid enum value for {typeof(T)}.");
+                throw new InvalidEnumArgumentException(parameterName, Convert.ToInt32(input), typeof(T));
             }
 
             return input;
@@ -529,7 +529,7 @@ namespace Ardalis.GuardClauses
         {
             if (!Enum.IsDefined(typeof(T), input))
             {
-                throw new InvalidEnumArgumentException($"Required input {parameterName} was not a valid enum value for {typeof(T)}.");
+                throw new InvalidEnumArgumentException(parameterName, Convert.ToInt32(input), typeof(T));
             }
 
             return input;

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
@@ -1,5 +1,4 @@
 ﻿using Ardalis.GuardClauses;
-using System;
 using System.ComponentModel;
 using Xunit;
 
@@ -26,7 +25,8 @@ namespace GuardClauses.UnitTests
         [InlineData(10)]
         public void ThrowsGivenOutOfRangeValue(int enumValue)
         {
-            Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.OutOfRange<TestEnum>(enumValue, nameof(enumValue)));
+            var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.OutOfRange<TestEnum>(enumValue, nameof(enumValue)));
+            Assert.Equal(nameof(enumValue), exception.ParamName);
         }
 
         [Theory]
@@ -48,7 +48,8 @@ namespace GuardClauses.UnitTests
         [InlineData((TestEnum) 10)]
         public void ThrowsGivenOutOfRangeEnum(TestEnum enumValue)
         {
-            Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.OutOfRange(enumValue, nameof(enumValue)));
+            var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.OutOfRange(enumValue, nameof(enumValue)));
+            Assert.Equal(nameof(enumValue), exception.ParamName);
         }
 
         [Theory]


### PR DESCRIPTION
Suggested fix for #79.