### PR TITLE
Remove double check from NullOrWhitespace

### DIFF
--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -109,7 +109,6 @@ namespace Ardalis.GuardClauses
         /// <exception cref="ArgumentException"></exception>
         public static string NullOrWhiteSpace([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input, [JetBrainsNotNull] string parameterName)
         {
-            Guard.Against.NullOrEmpty(input, parameterName);
             if (String.IsNullOrWhiteSpace(input))
             {
                 throw new ArgumentException($"Required input {parameterName} was empty.", parameterName);

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -21,7 +21,7 @@ namespace GuardClauses.UnitTests
         [Fact]
         public void ThrowsGivenNullValue()
         {
-            Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(null, "null"));
+            Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(null, "null"));
         }
 
         [Fact]


### PR DESCRIPTION
- Null or Whitespace will throw the same exception as null or empty.


https://github.com/ardalis/GuardClauses/blob/d4f1d819d9e28fef1fe2c923af8a23bf7b9e240a/src/GuardClauses/GuardClauseExtensions.cs#L112