### PR TITLE
Added NotFound extension.

### DIFF
--- a/src/GuardClauses/Exceptions/NotFoundException.cs
+++ b/src/GuardClauses/Exceptions/NotFoundException.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.GuardClauses
+{
+    /// <summary>
+    /// Represents error that occurs if a queried object by a particular key is null (not found).
+    /// </summary>
+    public class NotFoundException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the NotFoundException class with a specified name of the queried object and its key.
+        /// </summary>
+        /// <param name="objectName">Name of the queried object.</param>
+        /// <param name="key">The value by which the object is queried.</param>
+        public NotFoundException(string key, string objectName)
+            : base($"Queried object {objectName} was not found, Key: {key}")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the NotFoundException class with a specified name of the queried object, its key,
+        /// and the exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="objectName">Name of the queried object.</param>
+        /// <param name="key">The value by which the object is queried.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
+        public NotFoundException(string key, string objectName, Exception innerException)
+            : base($"Queried object {objectName} was not found, Key: {key}", innerException)
+        {
+        }
+    }
+}

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -782,5 +782,51 @@ namespace Ardalis.GuardClauses
         {
             return OutOfRange<TimeSpan>(guardClause, input, parameterName, rangeFrom, rangeTo);
         }
+
+        /// <summary>
+        /// Throws an <see cref="NotFoundException" /> if <paramref name="input" /> with <paramref name="key" /> is not found.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="guardClause"></param>
+        /// <param name="key"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not null.</returns>
+        /// <exception cref="NotFoundException"></exception>
+        public static T NotFound<T>([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string key, [NotNull, JetBrainsNotNull][ValidatedNotNull] T input, [JetBrainsNotNull] string parameterName)
+        {
+            guardClause.NullOrEmpty(key, nameof(key));
+
+            if (input is null)
+            {
+                throw new NotFoundException(key, parameterName);
+            }
+
+            return input;
+        }
+
+        /// <summary>
+        /// Throws an <see cref="NotFoundException" /> if <paramref name="input" /> with <paramref name="key" /> is not found.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TKey"></typeparam>
+        /// <param name="guardClause"></param>
+        /// <param name="key"></param>
+        /// <param name="input"></param>
+        /// <param name="parameterName"></param>
+        /// <returns><paramref name="input" /> if the value is not null.</returns>
+        /// <exception cref="NotFoundException"></exception>
+        public static T NotFound<TKey, T>([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] TKey key, [NotNull, JetBrainsNotNull][ValidatedNotNull] T input, [JetBrainsNotNull] string parameterName) where TKey : struct
+        {
+            guardClause.Null(key, nameof(key));
+
+            if (input is null)
+            {
+                // TODO: Can we safely consider that ToString() won't return null for struct?
+                throw new NotFoundException(key.ToString()!, parameterName);
+            }
+
+            return input;
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNotFound.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNotFound.cs
@@ -1,0 +1,42 @@
+﻿using Ardalis.GuardClauses;
+using System;
+using Xunit;
+
+namespace GuardClauses.UnitTests
+{
+    public class GuardAgainstNotFound
+    {
+        [Fact]
+        public void DoesNothingGivenNonNullValue()
+        {
+            Guard.Against.NotFound("mykey", "", "string");
+            Guard.Against.NotFound(1, 1, "int");
+            Guard.Against.NotFound(1, Guid.Empty, "guid");
+            Guard.Against.NotFound(Guid.Empty, DateTime.Now, "datetime");
+            Guard.Against.NotFound(1, new Object(), "object");
+        }
+
+        [Fact]
+        public void ThrowsGivenNullValue()
+        {
+            object obj = null!;
+            Assert.Throws<NotFoundException>(() => Guard.Against.NotFound(1, obj, "null"));
+        }
+
+        [Fact]
+        public void ReturnsExpectedValueWhenGivenNonNullValue()
+        {
+            Assert.Equal("", Guard.Against.NotFound("mykey", "", "string"));
+            Assert.Equal(1, Guard.Against.NotFound(1, 1, "int"));
+
+            var guid = Guid.Empty;
+            Assert.Equal(guid, Guard.Against.NotFound(1, guid, "guid"));
+            
+            var now = DateTime.Now;
+            Assert.Equal(now, Guard.Against.NotFound(1, now, "datetime"));
+
+            var obj = new Object();
+            Assert.Equal(obj, Guard.Against.NotFound(1, obj, "object"));
+        }
+    }
+}


### PR DESCRIPTION
See issue #102.

PS. Not related to this PR, tests for `Guard.Against.InvalidInput` are failing since xunit version update. Took a brief look but couldn't figure out what's the issue.
![image](https://user-images.githubusercontent.com/24314310/116557430-b9f60600-a8fe-11eb-9615-a58974f674ce.png)
