### PR TITLE
Custom message as optional parameter or overload

### DIFF
--- a/src/GuardClauses/Exceptions/NotFoundException.cs
+++ b/src/GuardClauses/Exceptions/NotFoundException.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Ardalis.GuardClauses
 {

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -29,7 +29,11 @@ namespace Ardalis.GuardClauses
         {
             if (input is null)
             {
-                throw new ArgumentNullException(parameterName, message);
+                if (string.IsNullOrEmpty(message))
+                {
+                    throw new ArgumentNullException(parameterName);
+                }
+                throw new ArgumentNullException(message, (Exception?) null);
             }
 
             return input;
@@ -277,7 +281,11 @@ namespace Ardalis.GuardClauses
 
             if (comparer.Compare(input, rangeFrom) < 0 || comparer.Compare(input, rangeTo) > 0)
             {
-                throw new ArgumentOutOfRangeException(parameterName, message ?? $"Input {parameterName} was out of range");
+                if (string.IsNullOrEmpty(message))
+                {
+                    throw new ArgumentOutOfRangeException(parameterName, $"Input {parameterName} was out of range");
+                }
+                throw new ArgumentOutOfRangeException(message, (Exception?) null);
             }
 
             return input;
@@ -592,13 +600,18 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="InvalidEnumArgumentException"></exception>
-        public static int OutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName) where T : struct, Enum
+        public static int OutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName, string? message = null) where T : struct, Enum
         {
             if (!Enum.IsDefined(typeof(T), input))
             {
-                throw new InvalidEnumArgumentException(parameterName, Convert.ToInt32(input), typeof(T));
+                if (string.IsNullOrEmpty(message))
+                {
+                    throw new InvalidEnumArgumentException(parameterName, Convert.ToInt32(input), typeof(T));
+                }
+                throw new InvalidEnumArgumentException(message);
             }
 
             return input;
@@ -611,13 +624,18 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="InvalidEnumArgumentException"></exception>
-        public static T OutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName) where T : struct, Enum
+        public static T OutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName, string? message = null) where T : struct, Enum
         {
             if (!Enum.IsDefined(typeof(T), input))
             {
-                throw new InvalidEnumArgumentException(parameterName, Convert.ToInt32(input), typeof(T));
+                if (string.IsNullOrEmpty(message))
+                {
+                    throw new InvalidEnumArgumentException(parameterName, Convert.ToInt32(input), typeof(T));
+                }
+                throw new InvalidEnumArgumentException(message);
             }
 
             return input;
@@ -707,7 +725,11 @@ namespace Ardalis.GuardClauses
 
             if (input.Any(x => comparer.Compare(x, rangeFrom) < 0 || comparer.Compare(x, rangeTo) > 0))
             {
-                throw new ArgumentOutOfRangeException(parameterName, message ?? $"Input {parameterName} had out of range item(s)");
+                if (string.IsNullOrEmpty(message))
+                {
+                    throw new ArgumentOutOfRangeException(parameterName, message ?? $"Input {parameterName} had out of range item(s)");
+                }
+                throw new ArgumentOutOfRangeException(message, (Exception?) null);
             }
 
             return input;

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -23,12 +23,13 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not null.</returns>
-        public static T Null<T>([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] T input, [JetBrainsNotNull] string parameterName)
+        public static T Null<T>([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] T input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
             if (input is null)
             {
-                throw new ArgumentNullException(parameterName);
+                throw new ArgumentNullException(parameterName, message);
             }
 
             return input;
@@ -41,15 +42,16 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not an empty string or null.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public static string NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input, [JetBrainsNotNull] string parameterName)
+        public static string NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
             Guard.Against.Null(input, parameterName);
-            if (input == String.Empty)
+            if (input == string.Empty)
             {
-                throw new ArgumentException($"Required input {parameterName} was empty.", parameterName);
+                throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
             }
 
             return input;
@@ -62,15 +64,16 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not an empty guid or null.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public static Guid NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] Guid? input, [JetBrainsNotNull] string parameterName)
+        public static Guid NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] Guid? input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
             Guard.Against.Null(input, parameterName);
             if (input == Guid.Empty)
             {
-                throw new ArgumentException($"Required input {parameterName} was empty.", parameterName);
+                throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
             }
 
             return input.Value;
@@ -83,15 +86,16 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not an empty enumerable or null.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public static IEnumerable<T> NullOrEmpty<T>([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] IEnumerable<T>? input, [JetBrainsNotNull] string parameterName)
+        public static IEnumerable<T> NullOrEmpty<T>([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] IEnumerable<T>? input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
             Guard.Against.Null(input, parameterName);
             if (!input.Any())
             {
-                throw new ArgumentException($"Required input {parameterName} was empty.", parameterName);
+                throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
             }
 
             return input;
@@ -104,15 +108,16 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not an empty or whitespace string.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public static string NullOrWhiteSpace([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input, [JetBrainsNotNull] string parameterName)
+        public static string NullOrWhiteSpace([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
             Guard.Against.NullOrEmpty(input, parameterName);
             if (String.IsNullOrWhiteSpace(input))
             {
-                throw new ArgumentException($"Required input {parameterName} was empty.", parameterName);
+                throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
             }
 
             return input;
@@ -126,12 +131,13 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is inside the given range.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static int OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName, int rangeFrom, int rangeTo)
+        public static int OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName, int rangeFrom, int rangeTo, string? message = null)
         {
-            return OutOfRange<int>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<int>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -142,12 +148,13 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is inside the given range.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static DateTime OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, DateTime input, [JetBrainsNotNull] string parameterName, DateTime rangeFrom, DateTime rangeTo)
+        public static DateTime OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, DateTime input, [JetBrainsNotNull] string parameterName, DateTime rangeFrom, DateTime rangeTo, string? message = null)
         {
-            return OutOfRange<DateTime>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<DateTime>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -156,15 +163,16 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static DateTime OutOfSQLDateRange([JetBrainsNotNull] this IGuardClause guardClause, DateTime input, [JetBrainsNotNull] string parameterName)
+        public static DateTime OutOfSQLDateRange([JetBrainsNotNull] this IGuardClause guardClause, DateTime input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
             // System.Data is unavailable in .NET Standard so we can't use SqlDateTime.
             const long sqlMinDateTicks = 552877920000000000;
             const long sqlMaxDateTicks = 3155378975999970000;
 
-            return OutOfRange<DateTime>(guardClause, input, parameterName, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks));
+            return OutOfRange<DateTime>(guardClause, input, parameterName, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks), message);
         }
 
         /// <summary>
@@ -175,11 +183,12 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static decimal OutOfRange(this IGuardClause guardClause, decimal input, string parameterName, decimal rangeFrom, decimal rangeTo)
+        public static decimal OutOfRange(this IGuardClause guardClause, decimal input, string parameterName, decimal rangeFrom, decimal rangeTo, string? message = null)
         {
-            return OutOfRange<decimal>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<decimal>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -190,11 +199,12 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static short OutOfRange(this IGuardClause guardClause, short input, string parameterName, short rangeFrom, short rangeTo)
+        public static short OutOfRange(this IGuardClause guardClause, short input, string parameterName, short rangeFrom, short rangeTo, string? message = null)
         {
-            return OutOfRange<short>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<short>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -205,11 +215,12 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static double OutOfRange(this IGuardClause guardClause, double input, string parameterName, double rangeFrom, double rangeTo)
+        public static double OutOfRange(this IGuardClause guardClause, double input, string parameterName, double rangeFrom, double rangeTo, string? message = null)
         {
-            return OutOfRange<double>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<double>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -220,11 +231,12 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static float OutOfRange(this IGuardClause guardClause, float input, string parameterName, float rangeFrom, float rangeTo)
+        public static float OutOfRange(this IGuardClause guardClause, float input, string parameterName, float rangeFrom, float rangeTo, string? message = null)
         {
-            return OutOfRange<float>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<float>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -235,11 +247,12 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static TimeSpan OutOfRange(this IGuardClause guardClause, TimeSpan input, string parameterName, TimeSpan rangeFrom, TimeSpan rangeTo)
+        public static TimeSpan OutOfRange(this IGuardClause guardClause, TimeSpan input, string parameterName, TimeSpan rangeFrom, TimeSpan rangeTo, string? message = null)
         {
-            return OutOfRange<TimeSpan>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<TimeSpan>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -250,20 +263,21 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        private static T OutOfRange<T>(this IGuardClause guardClause, T input, string parameterName, T rangeFrom, T rangeTo)
+        private static T OutOfRange<T>(this IGuardClause guardClause, T input, string parameterName, T rangeFrom, T rangeTo, string? message = null)
         {
             Comparer<T> comparer = Comparer<T>.Default;
 
             if (comparer.Compare(rangeFrom, rangeTo) > 0)
             {
-                throw new ArgumentException($"{nameof(rangeFrom)} should be less or equal than {nameof(rangeTo)}");
+                throw new ArgumentException(message ?? $"{nameof(rangeFrom)} should be less or equal than {nameof(rangeTo)}");
             }
 
             if (comparer.Compare(input, rangeFrom) < 0 || comparer.Compare(input, rangeTo) > 0)
             {
-                throw new ArgumentOutOfRangeException(parameterName, $"Input {parameterName} was out of range");
+                throw new ArgumentOutOfRangeException(parameterName, message ?? $"Input {parameterName} was out of range");
             }
 
             return input;
@@ -275,11 +289,12 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static int Zero([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName)
+        public static int Zero([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return Zero<int>(guardClause, input, parameterName);
+            return Zero<int>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -288,11 +303,12 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static long Zero([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull] string parameterName)
+        public static long Zero([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return Zero<long>(guardClause, input, parameterName);
+            return Zero<long>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -301,11 +317,12 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static decimal Zero([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull] string parameterName)
+        public static decimal Zero([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return Zero<decimal>(guardClause, input, parameterName);
+            return Zero<decimal>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -314,11 +331,12 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static float Zero([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull] string parameterName)
+        public static float Zero([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return Zero<float>(guardClause, input, parameterName);
+            return Zero<float>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -327,11 +345,12 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static double Zero([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull] string parameterName)
+        public static double Zero([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return Zero<double>(guardClause, input, parameterName);
+            return Zero<double>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -353,13 +372,14 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        private static T Zero<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName) where T : struct
+        private static T Zero<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName, string? message = null) where T : struct
         {
             if (EqualityComparer<T>.Default.Equals(input, default(T)))
             {
-                throw new ArgumentException($"Required input {parameterName} cannot be zero.", parameterName);
+                throw new ArgumentException(message ?? $"Required input {parameterName} cannot be zero.", parameterName);
             }
 
             return input;
@@ -371,11 +391,12 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static int Negative([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName)
+        public static int Negative([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return Negative<int>(guardClause, input, parameterName);
+            return Negative<int>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -384,11 +405,12 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static long Negative([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull] string parameterName)
+        public static long Negative([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return Negative<long>(guardClause, input, parameterName);
+            return Negative<long>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -397,11 +419,12 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static decimal Negative([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull] string parameterName)
+        public static decimal Negative([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return Negative<decimal>(guardClause, input, parameterName);
+            return Negative<decimal>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -410,11 +433,12 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static float Negative([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull] string parameterName)
+        public static float Negative([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return Negative<float>(guardClause, input, parameterName);
+            return Negative<float>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -423,11 +447,12 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static double Negative([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull] string parameterName)
+        public static double Negative([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return Negative<double>(guardClause, input, parameterName);
+            return Negative<double>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -436,11 +461,12 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static TimeSpan Negative([JetBrainsNotNull] this IGuardClause guardClause, TimeSpan input, [JetBrainsNotNull] string parameterName)
+        public static TimeSpan Negative([JetBrainsNotNull] this IGuardClause guardClause, TimeSpan input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return Negative<TimeSpan>(guardClause, input, parameterName);
+            return Negative<TimeSpan>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -449,13 +475,14 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        private static T Negative<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName) where T : struct, IComparable
+        private static T Negative<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName, string? message = null) where T : struct, IComparable
         {
             if (input.CompareTo(default(T)) < 0)
             {
-                throw new ArgumentException($"Required input {parameterName} cannot be negative.", parameterName);
+                throw new ArgumentException(message ?? $"Required input {parameterName} cannot be negative.", parameterName);
             }
 
             return input;
@@ -467,10 +494,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        public static int NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName)
+        public static int NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return NegativeOrZero<int>(guardClause, input, parameterName);
+            return NegativeOrZero<int>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -479,10 +507,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        public static long NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull] string parameterName)
+        public static long NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return NegativeOrZero<long>(guardClause, input, parameterName);
+            return NegativeOrZero<long>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -491,10 +520,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        public static decimal NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull] string parameterName)
+        public static decimal NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return NegativeOrZero<decimal>(guardClause, input, parameterName);
+            return NegativeOrZero<decimal>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -503,10 +533,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        public static float NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull] string parameterName)
+        public static float NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return NegativeOrZero<float>(guardClause, input, parameterName);
+            return NegativeOrZero<float>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -515,10 +546,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        public static double NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull] string parameterName)
+        public static double NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return NegativeOrZero<double>(guardClause, input, parameterName);
+            return NegativeOrZero<double>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -527,10 +559,11 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        public static TimeSpan NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, TimeSpan input, [JetBrainsNotNull] string parameterName)
+        public static TimeSpan NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, TimeSpan input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
-            return NegativeOrZero<TimeSpan>(guardClause, input, parameterName);
+            return NegativeOrZero<TimeSpan>(guardClause, input, parameterName, message);
         }
 
         /// <summary>
@@ -540,12 +573,13 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        private static T NegativeOrZero<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName) where T : struct, IComparable
+        private static T NegativeOrZero<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName, string? message = null) where T : struct, IComparable
         {
             if (input.CompareTo(default(T)) <= 0)
             {
-                throw new ArgumentException($"Required input {parameterName} cannot be zero or negative.", parameterName);
+                throw new ArgumentException(message ?? $"Required input {parameterName} cannot be zero or negative.", parameterName);
             }
 
             return input;
@@ -595,13 +629,14 @@ namespace Ardalis.GuardClauses
         /// <param name="guardClause"></param>
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not default for that type.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static T Default<T>([JetBrainsNotNull] this IGuardClause guardClause, [AllowNull, NotNull, JetBrainsNotNull] T input, [JetBrainsNotNull] string parameterName)
+        public static T Default<T>([JetBrainsNotNull] this IGuardClause guardClause, [AllowNull, NotNull, JetBrainsNotNull] T input, [JetBrainsNotNull] string parameterName, string? message = null)
         {
             if (EqualityComparer<T>.Default.Equals(input, default(T)!) || input is null)
             {
-                throw new ArgumentException($"Parameter [{parameterName}] is default value for type {typeof(T).Name}", parameterName);
+                throw new ArgumentException(message ?? $"Parameter [{parameterName}] is default value for type {typeof(T).Name}", parameterName);
             }
 
             return input;
@@ -614,12 +649,15 @@ namespace Ardalis.GuardClauses
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
         /// <param name="regexPattern"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns></returns>
         /// <exception cref="ArgumentException"></exception>
-        public static string InvalidFormat([JetBrainsNotNull] this IGuardClause guardClause, [JetBrainsNotNull] string input, [JetBrainsNotNull] string parameterName, [JetBrainsNotNull] string regexPattern)
+        public static string InvalidFormat([JetBrainsNotNull] this IGuardClause guardClause, [JetBrainsNotNull] string input, [JetBrainsNotNull] string parameterName, [JetBrainsNotNull] string regexPattern, string? message = null)
         {
             if (input != Regex.Match(input, regexPattern).Value)
-                throw new ArgumentException($"Input {parameterName} was not in required format", parameterName);
+            {
+                throw new ArgumentException(message ?? $"Input {parameterName} was not in required format", parameterName);
+            }
 
             return input;
         }
@@ -631,13 +669,16 @@ namespace Ardalis.GuardClauses
         /// <param name="input"></param>
         /// <param name="parameterName"></param>
         /// <param name="predicate"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         /// <exception cref="ArgumentException"></exception>
-        public static T InvalidInput<T>([JetBrainsNotNull] this IGuardClause guardClause, [JetBrainsNotNull] T input, [JetBrainsNotNull] string parameterName, Func<T, bool> predicate)
+        public static T InvalidInput<T>([JetBrainsNotNull] this IGuardClause guardClause, [JetBrainsNotNull] T input, [JetBrainsNotNull] string parameterName, Func<T, bool> predicate, string? message = null)
         {
             if (!predicate(input))
-                throw new ArgumentException($"Input {parameterName} did not satisfy the options", parameterName);
+            {
+                throw new ArgumentException(message ?? $"Input {parameterName} did not satisfy the options", parameterName);
+            }
 
             return input;
         }
@@ -651,21 +692,22 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if any item is not out of range.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        private static IEnumerable<T> OutOfRange<T>(this IGuardClause guardClause, IEnumerable<T> input, string parameterName, T rangeFrom, T rangeTo) where T : IComparable
+        private static IEnumerable<T> OutOfRange<T>(this IGuardClause guardClause, IEnumerable<T> input, string parameterName, T rangeFrom, T rangeTo, string? message = null) where T : IComparable
         {
             Comparer<T> comparer = Comparer<T>.Default;
 
             if (comparer.Compare(rangeFrom, rangeTo) > 0)
             {
-                throw new ArgumentException($"{nameof(rangeFrom)} should be less or equal than {nameof(rangeTo)}");
+                throw new ArgumentException(message ?? $"{nameof(rangeFrom)} should be less or equal than {nameof(rangeTo)}");
             }
 
             if (input.Any(x => comparer.Compare(x, rangeFrom) < 0 || comparer.Compare(x, rangeTo) > 0))
             {
-                throw new ArgumentOutOfRangeException(parameterName, $"Input {parameterName} had out of range item(s)");
+                throw new ArgumentOutOfRangeException(parameterName, message ?? $"Input {parameterName} had out of range item(s)");
             }
 
             return input;
@@ -679,12 +721,13 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if any item is not out of range.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static IEnumerable<int> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<int> input, [JetBrainsNotNull] string parameterName, int rangeFrom, int rangeTo)
+        public static IEnumerable<int> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<int> input, [JetBrainsNotNull] string parameterName, int rangeFrom, int rangeTo, string? message = null)
         {
-            return OutOfRange<int>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<int>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -695,12 +738,13 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if any item is not out of range.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static IEnumerable<long> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<long> input, [JetBrainsNotNull] string parameterName, long rangeFrom, long rangeTo)
+        public static IEnumerable<long> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<long> input, [JetBrainsNotNull] string parameterName, long rangeFrom, long rangeTo, string? message = null)
         {
-            return OutOfRange<long>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<long>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -711,12 +755,13 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if any item is not out of range.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static IEnumerable<decimal> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<decimal> input, [JetBrainsNotNull] string parameterName, decimal rangeFrom, decimal rangeTo)
+        public static IEnumerable<decimal> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<decimal> input, [JetBrainsNotNull] string parameterName, decimal rangeFrom, decimal rangeTo, string? message = null)
         {
-            return OutOfRange<decimal>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<decimal>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -727,12 +772,13 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if any item is not out of range.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static IEnumerable<float> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<float> input, [JetBrainsNotNull] string parameterName, float rangeFrom, float rangeTo)
+        public static IEnumerable<float> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<float> input, [JetBrainsNotNull] string parameterName, float rangeFrom, float rangeTo, string? message = null)
         {
-            return OutOfRange<float>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<float>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -743,12 +789,13 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if any item is not out of range.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static IEnumerable<double> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<double> input, [JetBrainsNotNull] string parameterName, double rangeFrom, double rangeTo)
+        public static IEnumerable<double> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<double> input, [JetBrainsNotNull] string parameterName, double rangeFrom, double rangeTo, string? message = null)
         {
-            return OutOfRange<double>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<double>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -759,12 +806,13 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if any item is not out of range.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static IEnumerable<short> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<short> input, [JetBrainsNotNull] string parameterName, short rangeFrom, short rangeTo)
+        public static IEnumerable<short> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<short> input, [JetBrainsNotNull] string parameterName, short rangeFrom, short rangeTo, string? message = null)
         {
-            return OutOfRange<short>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<short>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>
@@ -775,12 +823,13 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="rangeFrom"></param>
         /// <param name="rangeTo"></param>
+        /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if any item is not out of range.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static IEnumerable<TimeSpan> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<TimeSpan> input, [JetBrainsNotNull] string parameterName, TimeSpan rangeFrom, TimeSpan rangeTo)
+        public static IEnumerable<TimeSpan> OutOfRange([JetBrainsNotNull] this IGuardClause guardClause, IEnumerable<TimeSpan> input, [JetBrainsNotNull] string parameterName, TimeSpan rangeFrom, TimeSpan rangeTo, string? message = null)
         {
-            return OutOfRange<TimeSpan>(guardClause, input, parameterName, rangeFrom, rangeTo);
+            return OutOfRange<TimeSpan>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
         }
 
         /// <summary>

--- a/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
@@ -105,5 +105,16 @@ namespace GuardClauses.UnitTests
             Assert.Equal(TimeSpan.Zero, Guard.Against.Negative(TimeSpan.Zero, "timespanZero"));
             Assert.Equal(TimeSpan.FromSeconds(1), Guard.Against.Negative(TimeSpan.FromSeconds(1), "timespanOne"));
         }
+
+        [Theory]
+        [InlineData(null, "Required input parameterName cannot be negative.")]
+        [InlineData("Must be positive", "Must be positive")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1, "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
@@ -108,5 +108,16 @@ namespace GuardClauses.UnitTests
             Assert.Equal(1.0, Guard.Against.NegativeOrZero(1.0, "doublePositive"));
             Assert.Equal(TimeSpan.FromSeconds(1), Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(1), "timespanPositive"));
         }
+
+        [Theory]
+        [InlineData(null, "Required input parameterName cannot be zero or negative.")]
+        [InlineData("Value must exceed ZERO", "Value must exceed ZERO")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0, "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNull.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNull.cs
@@ -1,4 +1,4 @@
-using Ardalis.GuardClauses;
+﻿using Ardalis.GuardClauses;
 using System;
 using Xunit;
 
@@ -37,6 +37,18 @@ namespace GuardClauses.UnitTests
 
             var obj = new Object();
             Assert.Equal(obj, Guard.Against.Null(obj, "object"));
+        }
+
+        [Theory]
+        [InlineData(null, "Exception of type 'System.ArgumentNullException' was thrown.")]
+        [InlineData("Please provide value", "Please provide value")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            string? nullString = null;
+            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(nullString, "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNull.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNull.cs
@@ -40,7 +40,7 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Exception of type 'System.ArgumentNullException' was thrown.")]
+        [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
         [InlineData("Please provide value", "Please provide value")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
@@ -48,7 +48,7 @@ namespace GuardClauses.UnitTests
             var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(nullString, "parameterName", customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
@@ -1,4 +1,4 @@
-using Ardalis.GuardClauses;
+﻿using Ardalis.GuardClauses;
 using System;
 using System.Linq;
 using Xunit;
@@ -70,6 +70,17 @@ namespace GuardClauses.UnitTests
 
             var collection2 = new[] {1, 2};
             Assert.Equal(collection2, Guard.Against.NullOrEmpty(collection2, "intArray"));
+        }
+
+        [Theory]
+        [InlineData(null, "Required input parameterName was empty.")]
+        [InlineData("Value is empty", "Value is empty")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(string.Empty, "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -49,5 +49,16 @@ namespace GuardClauses.UnitTests
             Assert.Equal(expected, Guard.Against.NullOrWhiteSpace(nonEmptyString, "string"));
             Assert.Equal(expected, Guard.Against.NullOrWhiteSpace(nonEmptyString, "aNumericString"));
         }
+
+        [Theory]
+        [InlineData(null, "Required input parameterName was empty.")]
+        [InlineData("Value is empty", "Value is empty")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(" ", "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
@@ -55,6 +55,16 @@ namespace GuardClauses.UnitTests
             Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
         }
 
-
+        [Theory]
+        [InlineData(null, "Input parameterName was out of range")]
+        [InlineData("DateTime range", "DateTime range")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(DateTime.Today.AddDays(-1), "parameterName",
+                DateTime.Today, DateTime.Today.AddDays(1), customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
@@ -56,7 +56,7 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Input parameterName was out of range")]
+        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
         [InlineData("DateTime range", "DateTime range")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
@@ -64,7 +64,7 @@ namespace GuardClauses.UnitTests
                 DateTime.Today, DateTime.Today.AddDays(1), customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
@@ -43,5 +43,16 @@ namespace GuardClauses.UnitTests
         {
             Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
         }
+
+        [Theory]
+        [InlineData(null, "Input parameterName was out of range")]
+        [InlineData("Decimal range", "Decimal range")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0, "parameterName", 0.0, 1.0, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
@@ -45,14 +45,14 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Input parameterName was out of range")]
+        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
         [InlineData("Decimal range", "Decimal range")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0, "parameterName", 0.0, 1.0, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
@@ -45,14 +45,14 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Input parameterName was out of range")]
+        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
         [InlineData("Double range", "Double range")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0d, "parameterName", 0.0d, 1.0d, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
@@ -43,5 +43,16 @@ namespace GuardClauses.UnitTests
         {
             Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
         }
+
+        [Theory]
+        [InlineData(null, "Input parameterName was out of range")]
+        [InlineData("Double range", "Double range")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0d, "parameterName", 0.0d, 1.0d, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDecimal.cs
@@ -70,5 +70,16 @@ namespace GuardClauses.UnitTests
             }
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
+
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void CustomErrorMessage(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
+        {
+            var message = "Incorrect Range";
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, message));
+            Assert.NotNull(exception);
+            Assert.NotEmpty(exception.Message);
+            Assert.Equal(message, exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDouble.cs
@@ -37,6 +37,16 @@ namespace GuardClauses.UnitTests
             Assert.Equal(input, result);
         }
 
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void CustomErrorMessage(IEnumerable<double> input, double rangeFrom, double rangeTo)
+        {
+            var message = "Incorrect Range";
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, message));
+            Assert.NotNull(exception);
+            Assert.NotEmpty(exception.Message);
+            Assert.Equal(message, exception.Message);
+        }
 
         public class CorrectClassData : IEnumerable<object[]>
         {
@@ -73,5 +83,6 @@ namespace GuardClauses.UnitTests
             }
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
+
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableFloat.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableFloat.cs
@@ -37,6 +37,16 @@ namespace GuardClauses.UnitTests
             Assert.Equal(input, result);
         }
 
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void CustomErrorMessage(IEnumerable<float> input, float rangeFrom, float rangeTo)
+        {
+            var message = "Incorrect Range";
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, message));
+            Assert.NotNull(exception);
+            Assert.NotEmpty(exception.Message);
+            Assert.Equal(message, exception.Message);
+        }
 
         public class CorrectClassData : IEnumerable<object[]>
         {

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableInt.cs
@@ -37,6 +37,16 @@ namespace GuardClauses.UnitTests
             Assert.Equal(input, result);
         }
 
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void CustomErrorMessage(IEnumerable<int> input, int rangeFrom, int rangeTo)
+        {
+            var message = "Incorrect Range";
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, message));
+            Assert.NotNull(exception);
+            Assert.NotEmpty(exception.Message);
+            Assert.Equal(message, exception.Message);
+        }
 
         public class CorrectClassData : IEnumerable<object[]>
         {

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableLong.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableLong.cs
@@ -37,6 +37,16 @@ namespace GuardClauses.UnitTests
             Assert.Equal(input, result);
         }
 
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void CustomErrorMessage(IEnumerable<long> input, long rangeFrom, long rangeTo)
+        {
+            var message = "Incorrect Range";
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, message));
+            Assert.NotNull(exception);
+            Assert.NotEmpty(exception.Message);
+            Assert.Equal(message, exception.Message);
+        }
 
         public class CorrectClassData : IEnumerable<object[]>
         {

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableShort.cs
@@ -37,6 +37,17 @@ namespace GuardClauses.UnitTests
             Assert.Equal(input, result);
         }
 
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void CustomErrorMessage(IEnumerable<short> input, short rangeFrom, short rangeTo)
+        {
+            var message = "Incorrect Range";
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, message));
+            Assert.NotNull(exception);
+            Assert.NotEmpty(exception.Message);
+            Assert.Equal(message, exception.Message);
+        }
+
 
         public class CorrectClassData : IEnumerable<object[]>
         {

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableTimeSpan.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableTimeSpan.cs
@@ -54,7 +54,22 @@ namespace GuardClauses.UnitTests
             Assert.Equal(inputTimeSpan, result);
         }
 
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void CustomErrorMessage(IEnumerable<int> input, int rangeFrom, int rangeTo)
+        {
+            var message = "Incorrect Range";
+            var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
+            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
 
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan, message));
+
+            Assert.NotNull(exception);
+            Assert.NotEmpty(exception.Message);
+            Assert.Equal(message, exception.Message);
+        }
+        
         public class CorrectClassData : IEnumerable<object[]>
         {
             public IEnumerator<object[]> GetEnumerator()

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
@@ -43,5 +43,16 @@ namespace GuardClauses.UnitTests
         {
             Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
         }
+
+        [Theory]
+        [InlineData(null, "Input parameterName was out of range")]
+        [InlineData("Float range", "Float range")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0f, "parameterName", 0.0f, 1.0f, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
@@ -45,14 +45,14 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Input parameterName was out of range")]
+        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
         [InlineData("Float range", "Float range")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0f, "parameterName", 0.0f, 1.0f, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
@@ -43,5 +43,16 @@ namespace GuardClauses.UnitTests
         {
             Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
         }
+
+        [Theory]
+        [InlineData(null, "Input parameterName was out of range")]
+        [InlineData("Int range", "Int range")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3, "parameterName", 0, 1, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
@@ -45,14 +45,14 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Input parameterName was out of range")]
+        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
         [InlineData("Int range", "Int range")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3, "parameterName", 0, 1, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInvalidInput.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInvalidInput.cs
@@ -31,6 +31,17 @@ namespace GuardClauses.UnitTests
             Assert.Equal(input, result);
         }
 
+        [Theory]
+        [InlineData(null, "Input parameterName did not satisfy the options")]
+        [InlineData("Evaluation failed", "Evaluation failed")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidInput(10, "parameterName", x => x > 20, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+        }
+
         // TODO: Test decimal types outside of ClassData
         // See: https://github.com/xunit/xunit/issues/2298
         public class CorrectClassData : IEnumerable<object[]>

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
@@ -45,14 +45,14 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Input parameterName was out of range")]
+        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
         [InlineData("Short range", "Short range")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((short) 3, "parameterName", (short) 0, (short) 1, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
@@ -43,5 +43,16 @@ namespace GuardClauses.UnitTests
         {
             Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
         }
+
+        [Theory]
+        [InlineData(null, "Input parameterName was out of range")]
+        [InlineData("Short range", "Short range")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((short) 3, "parameterName", (short) 0, (short) 1, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForTimeSpan.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForTimeSpan.cs
@@ -60,5 +60,20 @@ namespace GuardClauses.UnitTests
 
             Assert.Equal(expectedTimeSpan, Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan));
         }
+
+        [Theory]
+        [InlineData(null, "rangeFrom should be less or equal than rangeTo")]
+        [InlineData("Timespan range", "Timespan range")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var inputTimeSpan = TimeSpan.FromSeconds(-1);
+            var rangeFromTimeSpan = TimeSpan.FromSeconds(3);
+            var rangeToTimeSpan = TimeSpan.FromSeconds(1);
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
@@ -1,6 +1,5 @@
 ﻿using Ardalis.GuardClauses;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Data.SqlTypes;
 using Xunit;
@@ -66,6 +65,19 @@ namespace GuardClauses.UnitTests
         public void ReturnsExpectedValueWhenGivenValidSqlDateTime(DateTime input, string name, DateTime expected)
         {
             Assert.Equal(expected, Guard.Against.OutOfSQLDateRange(input, name));
+        }
+
+        [Theory]
+        [InlineData(null, "Input date was out of range")]
+        [InlineData("SQLDate range", "SQLDate range")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-1);
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, nameof(date), customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + $" (Parameter '{nameof(date)}')", exception.Message);
         }
 
         public static IEnumerable<object[]> GetSqlDateTimeTestVectors()

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
@@ -68,7 +68,7 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Input date was out of range")]
+        [InlineData(null, "Input date was out of range (Parameter 'date'")]
         [InlineData("SQLDate range", "SQLDate range")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
@@ -77,7 +77,7 @@ namespace GuardClauses.UnitTests
 
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + $" (Parameter '{nameof(date)}')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
 
         public static IEnumerable<object[]> GetSqlDateTimeTestVectors()

--- a/test/GuardClauses.UnitTests/GuardAgainstZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstZero.cs
@@ -1,4 +1,4 @@
-using Ardalis.GuardClauses;
+﻿using Ardalis.GuardClauses;
 using System;
 using Xunit;
 
@@ -107,6 +107,17 @@ namespace GuardClauses.UnitTests
             Assert.Equal(float.MaxValue, Guard.Against.Zero(float.MaxValue, "float.MaxValue"));
             Assert.Equal(double.MinValue, Guard.Against.Zero(double.MinValue, "double.MinValue"));
             Assert.Equal(double.MaxValue, Guard.Against.Zero(double.MaxValue, "double.MaxValue"));
+        }
+
+        [Theory]
+        [InlineData(null, "Required input parameterName cannot be zero.")]
+        [InlineData("Value is ZERO", "Value is ZERO")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0, "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
         }
     }
 }


### PR DESCRIPTION
Hi Steve,

### Here is what I changed:
1. Implemented #97  as per recommendation
2. Added theory for each test class to expect the default message and custom error
3. One or two using references cleaned up

### Things I didn't change:
1. `InvalidEnumArgumentException` does not lend itself to accept a custom message. I did not apply the change to the `OutOfRange` methods for Enums.
2. I assumed that where another Guard is called, I do not carry the custom message across as per the example below. I feel the `ArgumentNullException` and `ArgumentException` would be slightly different concerns. :

```
  Guard.Against.Null(input, parameterName);
  if (input == string.Empty)
  {
      throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
  }
```


