### PR TITLE
Rename the Enum's `OutOfRange` to `EnumOutOfRange`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ public class Order
 - **Guard.Against.Null** (throws if input is null)
 - **Guard.Against.NullOrEmpty** (throws if string, guid or array input is null or empty)
 - **Guard.Against.NullOrWhiteSpace** (throws if string input is null, empty or whitespace)
-- **Guard.Against.OutOfRange** (throws if integer/DateTime/enum input is outside a provided range)
+- **Guard.Against.OutOfRange** (throws if integer/DateTime input is outside a provided range)
+- **Guard.Against.EnumOutOfRange** (throws if a enum value is outside a provided Enum range)
 - **Guard.Against.OutOfSQLDateRange** (throws if DateTime input is outside the valid range of SQL Server DateTime values)
 - **Guard.Against.Zero** (throws if number input is zero)
 

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -488,7 +488,7 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="InvalidEnumArgumentException"></exception>
-        public static int OutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName, string? message = null) where T : struct, Enum
+        public static int EnumOutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull] string parameterName, string? message = null) where T : struct, Enum
         {
             if (!Enum.IsDefined(typeof(T), input))
             {
@@ -512,7 +512,7 @@ namespace Ardalis.GuardClauses
         /// /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="InvalidEnumArgumentException"></exception>
-        public static T OutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName, string? message = null) where T : struct, Enum
+        public static T EnumOutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull] string parameterName, string? message = null) where T : struct, Enum
         {
             if (!Enum.IsDefined(typeof(T), input))
             {

--- a/src/GuardClauses/GuardClauses.csproj
+++ b/src/GuardClauses/GuardClauses.csproj
@@ -12,8 +12,8 @@
     <Summary>A simple package with guard clause helper methods. See docs for how to extend using your own extension methods.</Summary>
     <RepositoryUrl>https://github.com/ardalis/guardclauses</RepositoryUrl>
     <PackageTags>guard clause clauses assert assertion</PackageTags>
-    <PackageReleaseNotes>Added a new guard for NotFound; added support for optional custom error messages</PackageReleaseNotes>
-    <Version>3.2.0</Version>
+    <PackageReleaseNotes>Rename the Enum's `OutOfRange` to `EnumOutOfRange`</PackageReleaseNotes>
+    <Version>4.0.0</Version>
     <AssemblyName>Ardalis.GuardClauses</AssemblyName>
     <PackageIcon>icon.png</PackageIcon>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
@@ -15,7 +15,7 @@ namespace GuardClauses.UnitTests
         [InlineData(5)]
         public void DoesNothingGivenInRangeValue(int enumValue)
         {
-            Guard.Against.OutOfRange<TestEnum>(enumValue, nameof(enumValue));
+            Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue));
         }
         
 
@@ -25,7 +25,7 @@ namespace GuardClauses.UnitTests
         [InlineData(10)]
         public void ThrowsGivenOutOfRangeValue(int enumValue)
         {
-            var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.OutOfRange<TestEnum>(enumValue, nameof(enumValue)));
+            var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue)));
             Assert.Equal(nameof(enumValue), exception.ParamName);
         }
 
@@ -38,7 +38,7 @@ namespace GuardClauses.UnitTests
         [InlineData(TestEnum.Penguin)]
         public void DoesNothingGivenInRangeEnum(TestEnum enumValue)
         {
-            Guard.Against.OutOfRange(enumValue, nameof(enumValue));
+            Guard.Against.EnumOutOfRange(enumValue, nameof(enumValue));
         }
 
 
@@ -48,7 +48,7 @@ namespace GuardClauses.UnitTests
         [InlineData((TestEnum) 10)]
         public void ThrowsGivenOutOfRangeEnum(TestEnum enumValue)
         {
-            var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.OutOfRange(enumValue, nameof(enumValue)));
+            var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.EnumOutOfRange(enumValue, nameof(enumValue)));
             Assert.Equal(nameof(enumValue), exception.ParamName);
         }
 
@@ -62,7 +62,7 @@ namespace GuardClauses.UnitTests
         public void ReturnsExpectedValueGivenInRangeValue(int enumValue)
         {
             var expected = enumValue;
-            Assert.Equal(expected, Guard.Against.OutOfRange<TestEnum>(enumValue, nameof(enumValue)));
+            Assert.Equal(expected, Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue)));
         }
 
         [Theory]
@@ -75,7 +75,7 @@ namespace GuardClauses.UnitTests
         public void ReturnsExpectedValueGivenInRangeEnum(TestEnum enumValue)
         {
             var expected = enumValue;
-            Assert.Equal(expected, Guard.Against.OutOfRange(enumValue, nameof(enumValue)));
+            Assert.Equal(expected, Guard.Against.EnumOutOfRange(enumValue, nameof(enumValue)));
         }
         
     }


### PR DESCRIPTION
Hi, @ardalis I really enjoy your project and I'm, starting to do many contributions in the near future. And I am currently working in many of them.

This PR is to suggest a solution for a naming issue and a compiler issue when using `OutOfRange` classes See: #139

 - Rename the Enum's `OutOfRange` to `EnumOutOfRange` 
 - Dump Major version to signal a Breaking Change
                                                                                                   
Solves: #139
This is a *Breaking Change* 