### PR TITLE
Vr/bugfix custom message null or whitespace

### DIFF
--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -55,7 +55,7 @@ namespace Ardalis.GuardClauses
         /// <exception cref="ArgumentException"></exception>
         public static string NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
         {
-            Guard.Against.Null(input, parameterName);
+            Guard.Against.Null(input, parameterName, message);
             if (input == string.Empty)
             {
                 throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
@@ -121,7 +121,7 @@ namespace Ardalis.GuardClauses
         /// <exception cref="ArgumentException"></exception>
         public static string NullOrWhiteSpace([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
         {
-            Guard.Against.NullOrEmpty(input, parameterName);
+            Guard.Against.NullOrEmpty(input, parameterName, message);
             if (String.IsNullOrWhiteSpace(input))
             {
                 throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
@@ -75,12 +75,25 @@ namespace GuardClauses.UnitTests
         [Theory]
         [InlineData(null, "Required input parameterName was empty.")]
         [InlineData("Value is empty", "Value is empty")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        public void ErrorMessageMatchesExpectedWhenValueEmpty(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(string.Empty, "parameterName", customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
         }
+
+        [Theory]
+        [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
+        [InlineData("Value is empty", "Value is empty")]
+        public void ErrorMessageMatchesExpectedWhenValueNull(string customMessage, string expectedMessage)
+        {
+            string? value = null;
+            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(value, "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -53,12 +53,27 @@ namespace GuardClauses.UnitTests
         [Theory]
         [InlineData(null, "Required input parameterName was empty.")]
         [InlineData("Value is empty", "Value is empty")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        public void ErrorMessageMatchesExpectedWhenValueEmptyOrWhitespace(string customMessage, string expectedMessage)
         {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(" ", "parameterName", customMessage));
+            foreach (var value in new[] { string.Empty, " " })
+            {
+                var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(value, "parameterName", customMessage));
+                Assert.NotNull(exception);
+                Assert.NotNull(exception.Message);
+                Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            }
+        }
+
+        [Theory]
+        [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
+        [InlineData("Value is empty", "Value is empty")]
+        public void ErrorMessageMatchesExpectedWhenValueNull(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(null, "parameterName", customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
+
     }
 }


### PR DESCRIPTION
BugFix for isssue https://github.com/ardalis/GuardClauses/issues/150
- modified the tests ErrorMessageMatchesExpected for NullOrWhitespace and NullOrEmpty to check against null, string.empty and " "
- added the missing parameters to fix the issue

Remark: I noticed an inconsistency between Guard.Against.Null and Guard.Against.NullOrEmpty. When a value is null and a message is specified, then the text " (Parameter '...')" is not added. When the value is empty, the text " (Parameter '...') is added. This is because of this line: 

https://github.com/ardalis/GuardClauses/blob/95ba58b937fa99e3c774de552944219fb01ed5db/src/GuardClauses/GuardClauseExtensions.cs#L39

I did not change this, because that would be a breaking change. To make the messages consistent, this line must be changed to 

    throw new ArgumentNullException(parameterName, message); 
