### PR TITLE
Ensure InvalidFormat do not succeed with an empty input string if regex requires at least one char

### DIFF
--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -559,7 +559,8 @@ namespace Ardalis.GuardClauses
         /// <exception cref="ArgumentException"></exception>
         public static string InvalidFormat([JetBrainsNotNull] this IGuardClause guardClause, [JetBrainsNotNull] string input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, [JetBrainsNotNull][JetBrainsRegexPattern] string regexPattern, string? message = null)
         {
-            if (input != Regex.Match(input, regexPattern).Value)
+            var m = Regex.Match(input, regexPattern);
+            if (!m.Success || input != m.Value)
             {
                 throw new ArgumentException(message ?? $"Input {parameterName} was not in required format", parameterName);
             }

--- a/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
@@ -24,6 +24,7 @@ namespace GuardClauses.UnitTests
         [InlineData("2GudhUtG", @"[a-fA-F]+")]
         [InlineData("sDHSTRY", @"[A-Z]+")]
         [InlineData("3F498792", @"\d+")]
+        [InlineData("", @"\d+")]
         public void ThrowsGivenGivenIncorrectFormat(string input, string regexPattern)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat(input, nameof(input), regexPattern));


### PR DESCRIPTION
Small fix for InvalidFormat with an Empty String as Input