### PR TITLE
Fixed Parameter Name missing in Arg. Exceptions

### DIFF
--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -36,7 +36,7 @@ namespace Ardalis.GuardClauses
                 {
                     throw new ArgumentNullException(parameterName);
                 }
-                throw new ArgumentNullException(message, (Exception?)null);
+                throw new ArgumentNullException(parameterName, message);
             }
 
             return input;

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -605,7 +605,7 @@ namespace Ardalis.GuardClauses
         {
             if (rangeFrom.CompareTo(rangeTo) > 0)
             {
-                throw new ArgumentException(message ?? $"{nameof(rangeFrom)} should be less or equal than {nameof(rangeTo)}");
+                throw new ArgumentException(message ?? $"{nameof(rangeFrom)} should be less or equal than {nameof(rangeTo)}", parameterName);
             }
 
             if (input.Any(x => x.CompareTo(rangeFrom) < 0 || x.CompareTo(rangeTo) > 0))
@@ -614,7 +614,7 @@ namespace Ardalis.GuardClauses
                 {
                     throw new ArgumentOutOfRangeException(parameterName, message ?? $"Input {parameterName} had out of range item(s)");
                 }
-                throw new ArgumentOutOfRangeException(message, (Exception?)null);
+                throw new ArgumentOutOfRangeException(parameterName, message);
             }
 
             return input;

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -172,7 +172,7 @@ namespace Ardalis.GuardClauses
                 {
                     throw new ArgumentOutOfRangeException(parameterName, $"Input {parameterName} was out of range");
                 }
-                throw new ArgumentOutOfRangeException(message, (Exception?)null);
+                throw new ArgumentOutOfRangeException(parameterName, message);
             }
 
             return input;

--- a/src/GuardClauses/GuardClauseExtensions.cs
+++ b/src/GuardClauses/GuardClauseExtensions.cs
@@ -163,7 +163,7 @@ namespace Ardalis.GuardClauses
         {
             if (rangeFrom.CompareTo(rangeTo) > 0)
             {
-                throw new ArgumentException(message ?? $"{nameof(rangeFrom)} should be less or equal than {nameof(rangeTo)}");
+                throw new ArgumentException(message ?? $"{nameof(rangeFrom)} should be less or equal than {nameof(rangeTo)}", parameterName);
             }
 
             if (input.CompareTo(rangeFrom) < 0 || input.CompareTo(rangeTo) > 0)

--- a/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
@@ -37,7 +37,7 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, "Parameter [parameterName] is default value for type String (Parameter 'parameterName')")]
-        [InlineData("Please provide value", "Please provide value (Parameter 'parameterName')")]
+        [InlineData("Please provide correct value", "Please provide correct value (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Default(default(string), "parameterName", customMessage));
@@ -48,9 +48,9 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, null)]
-        [InlineData(null, "Please provide value")]
+        [InlineData(null, "Please provide correct value")]
         [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must not be null")]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
         public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
         {
             var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Default(default(string), expectedParamName, customMessage));

--- a/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
@@ -35,19 +35,42 @@ namespace GuardClauses.UnitTests
             Assert.Equal(expected, actual);
         }
 
+        [Theory]
+        [InlineData(null, "Parameter [parameterName] is default value for type String (Parameter 'parameterName')")]
+        [InlineData("Please provide value", "Please provide value (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Default(default(string), "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must not be null")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Default(default(string), expectedParamName, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
         public static IEnumerable<object[]> GetNonDefaultTestVectors()
         {
-            yield return new object[] {"", "string", ""};
-            yield return new object[] {1, "int", 1};
-            
+            yield return new object[] { "", "string", "" };
+            yield return new object[] { 1, "int", 1 };
+
             var guid = Guid.NewGuid();
-            yield return new object[] {guid, "guid", guid};
+            yield return new object[] { guid, "guid", guid };
 
             var now = DateTime.Now;
-            yield return new object[] {now, "now", now};
+            yield return new object[] { now, "now", now };
 
             var obj = new Object();
-            yield return new object[] {obj, "obj", obj};
+            yield return new object[] { obj, "obj", obj };
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstExpression.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstExpression.cs
@@ -63,5 +63,16 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.AgainstExpression((x) => x.FieldName == "FailThis", test, "FieldValue is not matching"));
         }
+
+        [Theory]
+        [InlineData(null, "Value does not fall within the expected range.")]
+        [InlineData("Please provide correct value", "Please provide correct value")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.AgainstExpression(x => x == 1, 2, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
@@ -42,9 +42,9 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, null)]
-        [InlineData(null, "Please provide value")]
+        [InlineData(null, "Please provide correct value")]
         [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must not be null")]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
         public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
         {
             var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat("aaa", expectedParamName, "^b", customMessage));

--- a/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
@@ -29,5 +29,27 @@ namespace GuardClauses.UnitTests
             Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat(input, nameof(input), regexPattern));
         }
 
+        [Theory]
+        [InlineData(null, "Input parameterName was not in required format (Parameter 'parameterName')")]
+        [InlineData("Please provide value in a correct format", "Please provide value in a correct format (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat("aaa", "parameterName", "^b", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must not be null")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat("aaa", expectedParamName, "^b", customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
@@ -119,7 +119,7 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, null)]
-        [InlineData(null, "Please provide value")]
+        [InlineData(null, "Please provide correct value")]
         [InlineData("SomeParameter", null)]
         [InlineData("SomeOtherParameter", "Value must be correct")]
         public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)

--- a/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
@@ -111,10 +112,23 @@ namespace GuardClauses.UnitTests
         [InlineData("Must be positive", "Must be positive (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1, "parameterName", customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
+            var clausesToEvaluate = new List<Action>
+            {
+                () => Guard.Against.Negative(-1, "parameterName", customMessage),
+                () => Guard.Against.Negative(-1L, "parameterName", customMessage),
+                () => Guard.Against.Negative(-1.0M, "parameterName", customMessage),
+                () => Guard.Against.Negative(-1.0f, "parameterName", customMessage),
+                () => Guard.Against.Negative(-1.0, "parameterName", customMessage),
+                () => Guard.Against.Negative(TimeSpan.FromSeconds(-1), "parameterName", customMessage)
+            };
+
+            foreach (var clauseToEvaluate in clausesToEvaluate)
+            {
+                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
+                Assert.NotNull(exception);
+                Assert.NotNull(exception.Message);
+                Assert.Equal(expectedMessage, exception.Message);
+            }
         }
 
         [Theory]
@@ -124,9 +138,22 @@ namespace GuardClauses.UnitTests
         [InlineData("SomeOtherParameter", "Value must be correct")]
         public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
         {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1, expectedParamName, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
+            var clausesToEvaluate = new List<Action>
+            {
+                () => Guard.Against.Negative(-1, expectedParamName, customMessage),
+                () => Guard.Against.Negative(-1L, expectedParamName, customMessage),
+                () => Guard.Against.Negative(-1.0M, expectedParamName, customMessage),
+                () => Guard.Against.Negative(-1.0f, expectedParamName, customMessage),
+                () => Guard.Against.Negative(-1.0, expectedParamName, customMessage),
+                () => Guard.Against.Negative(TimeSpan.FromSeconds(-1), expectedParamName, customMessage)
+            };
+
+            foreach (var clauseToEvaluate in clausesToEvaluate)
+            {
+                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
+                Assert.NotNull(exception);
+                Assert.Equal(expectedParamName, exception.ParamName);
+            }
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
@@ -107,14 +107,26 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Required input parameterName cannot be negative.")]
-        [InlineData("Must be positive", "Must be positive")]
+        [InlineData(null, "Required input parameterName cannot be negative. (Parameter 'parameterName')")]
+        [InlineData("Must be positive", "Must be positive (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1, "parameterName", customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1, expectedParamName, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
@@ -110,14 +110,26 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Required input parameterName cannot be zero or negative.")]
-        [InlineData("Value must exceed ZERO", "Value must exceed ZERO")]
+        [InlineData(null, "Required input parameterName cannot be zero or negative. (Parameter 'parameterName')")]
+        [InlineData("Value must exceed ZERO", "Value must exceed ZERO (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0, "parameterName", customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1, expectedParamName, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
@@ -110,26 +110,58 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Required input parameterName cannot be zero or negative. (Parameter 'parameterName')")]
-        [InlineData("Value must exceed ZERO", "Value must exceed ZERO (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        [InlineData(-1, null, "Required input parameterName cannot be zero or negative. (Parameter 'parameterName')")]
+        [InlineData(-1, "Must be positive", "Must be positive (Parameter 'parameterName')")]
+        [InlineData(0, null, "Required input parameterName cannot be zero or negative. (Parameter 'parameterName')")]
+        [InlineData(0, "Must be positive", "Must be positive (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpected(int input, string customMessage, string expectedMessage)
         {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0, "parameterName", customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
+            var clausesToEvaluate = new List<Action>
+            {
+                () => Guard.Against.NegativeOrZero(input, "parameterName", customMessage),
+                () => Guard.Against.NegativeOrZero((long)input, "parameterName", customMessage),
+                () => Guard.Against.NegativeOrZero((decimal)input, "parameterName", customMessage),
+                () => Guard.Against.NegativeOrZero((float)input, "parameterName", customMessage),
+                () => Guard.Against.NegativeOrZero((double)input, "parameterName", customMessage),
+                () => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(input), "parameterName", customMessage)
+            };
+
+            foreach (var clauseToEvaluate in clausesToEvaluate)
+            {
+                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
+                Assert.NotNull(exception);
+                Assert.NotNull(exception.Message);
+                Assert.Equal(expectedMessage, exception.Message);
+            }
         }
 
         [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        [InlineData(-1, null, null)]
+        [InlineData(-1, null, "Please provide correct value")]
+        [InlineData(-1, "SomeParameter", null)]
+        [InlineData(-1, "SomeOtherParameter", "Value must be correct")]
+        [InlineData(0, null, null)]
+        [InlineData(0, null, "Please provide correct value")]
+        [InlineData(0, "SomeParameter", null)]
+        [InlineData(0, "SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(int input, string expectedParamName, string customMessage)
         {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1, expectedParamName, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
+            var clausesToEvaluate = new List<Action>
+            {
+                () => Guard.Against.NegativeOrZero(input, expectedParamName, customMessage),
+                () => Guard.Against.NegativeOrZero((long)input, expectedParamName, customMessage),
+                () => Guard.Against.NegativeOrZero((decimal)input, expectedParamName, customMessage),
+                () => Guard.Against.NegativeOrZero((float)input, expectedParamName, customMessage),
+                () => Guard.Against.NegativeOrZero((double)input, expectedParamName, customMessage),
+                () => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(input), expectedParamName, customMessage)
+            };
+
+            foreach (var clauseToEvaluate in clausesToEvaluate)
+            {
+                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
+                Assert.NotNull(exception);
+                Assert.Equal(expectedParamName, exception.ParamName);
+            }
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNull.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNull.cs
@@ -41,7 +41,7 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
-        [InlineData("Please provide value", "Please provide value")]
+        [InlineData("Please provide value", "Please provide value (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             string? nullString = null;
@@ -49,6 +49,19 @@ namespace GuardClauses.UnitTests
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must not be null")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            string? nullString = null;
+            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(nullString, expectedParamName, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNull.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNull.cs
@@ -41,7 +41,7 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
-        [InlineData("Please provide value", "Please provide value (Parameter 'parameterName')")]
+        [InlineData("Please provide correct value", "Please provide correct value (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             string? nullString = null;
@@ -53,9 +53,9 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, null)]
-        [InlineData(null, "Please provide value")]
+        [InlineData(null, "Please provide correct value")]
         [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must not be null")]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
         public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
         {
             string? nullString = null;

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
@@ -73,14 +73,51 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Required input parameterName was empty.")]
-        [InlineData("Value is empty", "Value is empty")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        [InlineData(null, "Required input parameterName was empty. (Parameter 'parameterName')")]
+        [InlineData("Value is empty", "Value is empty (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenInputIsEmpty(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(string.Empty, "parameterName", customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
+        [InlineData("Value must be correct", "Value cannot be null. (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenInputIsNull(string customMessage, string expectedMessage)
+        {
+            string? nullString = null;
+            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullString, "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedWhenInputIsEmpty(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(string.Empty, expectedParamName, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedWhenInputIsNull(string expectedParamName, string customMessage)
+        {
+            string? nullString = null;
+            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullString, expectedParamName, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
@@ -1,5 +1,6 @@
 ﻿using Ardalis.GuardClauses;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -77,10 +78,24 @@ namespace GuardClauses.UnitTests
         [InlineData("Value is empty", "Value is empty (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpectedWhenInputIsEmpty(string customMessage, string expectedMessage)
         {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(string.Empty, "parameterName", customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
+            string emptyString = string.Empty;
+            Guid emptyGuid = Guid.Empty;
+            IEnumerable<string> emptyEnumerable = Enumerable.Empty<string>();
+
+            var clausesToEvaluate = new List<Action>
+            {
+                () => Guard.Against.NullOrEmpty(emptyString, "parameterName", customMessage),
+                () => Guard.Against.NullOrEmpty(emptyGuid, "parameterName", customMessage),
+                () => Guard.Against.NullOrEmpty(emptyEnumerable, "parameterName", customMessage)
+            };
+
+            foreach (var clauseToEvaluate in clausesToEvaluate)
+            {
+                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
+                Assert.NotNull(exception);
+                Assert.NotNull(exception.Message);
+                Assert.Equal(expectedMessage, exception.Message);
+            }
         }
 
         [Theory]
@@ -89,10 +104,23 @@ namespace GuardClauses.UnitTests
         public void ErrorMessageMatchesExpectedWhenInputIsNull(string customMessage, string expectedMessage)
         {
             string? nullString = null;
-            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullString, "parameterName", customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
+            Guid? nullGuid = null;
+            IEnumerable<string>? nullEnumerable = null;
+
+            var clausesToEvaluate = new List<Action>
+            {
+                () => Guard.Against.NullOrEmpty(nullString, "parameterName", customMessage),
+                () => Guard.Against.NullOrEmpty(nullGuid, "parameterName", customMessage),
+                () => Guard.Against.NullOrEmpty(nullEnumerable, "parameterName", customMessage)
+            };
+
+            foreach (var clauseToEvaluate in clausesToEvaluate)
+            {
+                var exception = Assert.Throws<ArgumentNullException>(clauseToEvaluate);
+                Assert.NotNull(exception);
+                Assert.NotNull(exception.Message);
+                Assert.Equal(expectedMessage, exception.Message);
+            }
         }
 
         [Theory]
@@ -102,9 +130,23 @@ namespace GuardClauses.UnitTests
         [InlineData("SomeOtherParameter", "Value must be correct")]
         public void ExceptionParamNameMatchesExpectedWhenInputIsEmpty(string expectedParamName, string customMessage)
         {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(string.Empty, expectedParamName, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
+            string emptyString = string.Empty;
+            Guid emptyGuid = Guid.Empty;
+            IEnumerable<string> emptyEnumerable = Enumerable.Empty<string>();
+
+            var clausesToEvaluate = new List<Action>
+            {
+                () => Guard.Against.NullOrEmpty(emptyString, expectedParamName, customMessage),
+                () => Guard.Against.NullOrEmpty(emptyGuid, expectedParamName, customMessage),
+                () => Guard.Against.NullOrEmpty(emptyEnumerable, expectedParamName, customMessage)
+            };
+
+            foreach (var clauseToEvaluate in clausesToEvaluate)
+            {
+                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
+                Assert.NotNull(exception);
+                Assert.Equal(expectedParamName, exception.ParamName);
+            }
         }
 
         [Theory]
@@ -115,9 +157,22 @@ namespace GuardClauses.UnitTests
         public void ExceptionParamNameMatchesExpectedWhenInputIsNull(string expectedParamName, string customMessage)
         {
             string? nullString = null;
-            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullString, expectedParamName, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
+            Guid? nullGuid = null;
+            IEnumerable<string>? nullEnumerable = null;
+
+            var clausesToEvaluate = new List<Action>
+            {
+                () => Guard.Against.NullOrEmpty(nullString, expectedParamName, customMessage),
+                () => Guard.Against.NullOrEmpty(nullGuid, expectedParamName, customMessage),
+                () => Guard.Against.NullOrEmpty(nullEnumerable, expectedParamName, customMessage)
+            };
+
+            foreach (var clauseToEvaluate in clausesToEvaluate)
+            {
+                var exception = Assert.Throws<ArgumentNullException>(clauseToEvaluate);
+                Assert.NotNull(exception);
+                Assert.Equal(expectedParamName, exception.ParamName);
+            }
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -51,14 +51,51 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Required input parameterName was empty.")]
-        [InlineData("Value is empty", "Value is empty")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        [InlineData(null, "Required input parameterName was empty. (Parameter 'parameterName')")]
+        [InlineData("Value is empty", "Value is empty (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenInputIsWhiteSpace(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(" ", "parameterName", customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
+        [InlineData("Value is null", "Value cannot be null. (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenInputIsNull(string customMessage, string expectedMessage)
+        {
+            string? nullString = null;
+            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(nullString, "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedWhenInputIsWhiteSpace(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(" ", expectedParamName, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedWhenInputIsNull(string expectedParamName, string customMessage)
+        {
+            string? nullString = null;
+            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(nullString, expectedParamName, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
@@ -57,7 +57,7 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("DateTime range", "DateTime range")]
+        [InlineData("DateTime range", "DateTime range (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(DateTime.Today.AddDays(-1), "parameterName",
@@ -65,6 +65,19 @@ namespace GuardClauses.UnitTests
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(DateTime.Today.AddDays(-1), expectedParamName,
+                DateTime.Today, DateTime.Today.AddDays(1), customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
@@ -46,13 +46,25 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Decimal range", "Decimal range")]
+        [InlineData("Decimal range", "Decimal range (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0, "parameterName", 0.0, 1.0, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0, expectedParamName, 0.0, 1.0, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
@@ -46,13 +46,25 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Double range", "Double range")]
+        [InlineData("Double range", "Double range (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0d, "parameterName", 0.0d, 1.0d, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0d, expectedParamName, 0.0d, 1.0d, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
@@ -77,7 +77,56 @@ namespace GuardClauses.UnitTests
             var expected = enumValue;
             Assert.Equal(expected, Guard.Against.OutOfRange(enumValue, nameof(enumValue)));
         }
-        
+
+        [Theory]
+        [InlineData(null, "The value of argument 'parameterName' (99) is invalid for Enum type 'TestEnum'. (Parameter 'parameterName')")]
+        [InlineData("Invalid enum value", "Invalid enum value")]
+        public void ErrorMessageMatchesExpectedWhenInputIsEnum(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<InvalidEnumArgumentException>(
+                () => Guard.Against.OutOfRange((TestEnum)99, "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData(null, "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedWhenInputIsEnum(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<InvalidEnumArgumentException>(
+                () => Guard.Against.OutOfRange((TestEnum)99, expectedParamName, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null, "The value of argument 'parameterName' (99) is invalid for Enum type 'TestEnum'. (Parameter 'parameterName')")]
+        [InlineData("Invalid enum value", "Invalid enum value")]
+        public void ErrorMessageMatchesExpectedWhenInputIsInt(string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<InvalidEnumArgumentException>(
+                () => Guard.Against.OutOfRange<TestEnum>(99, "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData(null, "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedWhenInputIsInt(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<InvalidEnumArgumentException>(
+                () => Guard.Against.OutOfRange<TestEnum>(99, expectedParamName, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
     }
 
 

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDecimal.cs
@@ -37,6 +37,67 @@ namespace GuardClauses.UnitTests
             Assert.Equal(input, result);
         }
 
+        [Theory]
+        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
+        {
+            var input = new[] { 0m, 1m, 99m };
+            decimal rangeFrom = 2m;
+            decimal rangeTo = 1m;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = new[] { 0m, 1m, 99m };
+            decimal rangeFrom = 2m;
+            decimal rangeTo = 1m;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+        {
+            var input = new[] { 0m, 1m, 99m };
+            decimal rangeFrom = 0m;
+            decimal rangeTo = 1m;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = new [] { 0m, 1m, 99m };
+            decimal rangeFrom = 0m;
+            decimal rangeTo = 1m;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
 
         public class CorrectClassData : IEnumerable<object[]>
         {
@@ -69,17 +130,6 @@ namespace GuardClauses.UnitTests
                 yield return new object[] { new List<decimal> { 52000.0m, 86.0m, 2500000.0m }, 20000000.0, 100.0 };
             }
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void CustomErrorMessage(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
-        {
-            var message = "Incorrect Range";
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, message));
-            Assert.NotNull(exception);
-            Assert.NotEmpty(exception.Message);
-            Assert.Equal(message, exception.Message);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDouble.cs
@@ -38,14 +38,65 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void CustomErrorMessage(IEnumerable<double> input, double rangeFrom, double rangeTo)
+        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
         {
-            var message = "Incorrect Range";
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, message));
+            var input = new [] { 0d, 1d, 99d };
+            double rangeFrom = 2d;
+            double rangeTo = 1d;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
             Assert.NotNull(exception);
-            Assert.NotEmpty(exception.Message);
-            Assert.Equal(message, exception.Message);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = new[] { 0d, 1d, 99d };
+            double rangeFrom = 2d;
+            double rangeTo = 1d;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+        {
+            var input = new[] { 0d, 1d, 99d };
+            double rangeFrom = 0d;
+            double rangeTo = 1d;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = new[] { 0d, 1d, 99d };
+            double rangeFrom = 0d;
+            double rangeTo = 1d;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
 
         public class CorrectClassData : IEnumerable<object[]>

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableFloat.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableFloat.cs
@@ -38,14 +38,65 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void CustomErrorMessage(IEnumerable<float> input, float rangeFrom, float rangeTo)
+        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
         {
-            var message = "Incorrect Range";
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, message));
+            var input = new[] { 0f, 1f, 99f };
+            float rangeFrom = 2f;
+            float rangeTo = 1f;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
             Assert.NotNull(exception);
-            Assert.NotEmpty(exception.Message);
-            Assert.Equal(message, exception.Message);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = new[] { 0f, 1f, 99f };
+            float rangeFrom = 2f;
+            float rangeTo = 1f;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+        {
+            var input = new[] { 0f, 1f, 99f };
+            float rangeFrom = 0f;
+            float rangeTo = 1f;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = new[] { 0f, 1f, 99f };
+            float rangeFrom = 0f;
+            float rangeTo = 1f;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
 
         public class CorrectClassData : IEnumerable<object[]>

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableInt.cs
@@ -38,14 +38,65 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void CustomErrorMessage(IEnumerable<int> input, int rangeFrom, int rangeTo)
+        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
         {
-            var message = "Incorrect Range";
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, message));
+            var input = new[] { 0, 1, 99 };
+            int rangeFrom = 2;
+            int rangeTo = 1;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
             Assert.NotNull(exception);
-            Assert.NotEmpty(exception.Message);
-            Assert.Equal(message, exception.Message);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = new[] { 0, 1, 99 };
+            int rangeFrom = 2;
+            int rangeTo = 1;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+        {
+            var input = new[] { 0, 1, 99 };
+            int rangeFrom = 0;
+            int rangeTo = 1;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = new[] { 0, 1, 99 };
+            int rangeFrom = 0;
+            int rangeTo = 1;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
 
         public class CorrectClassData : IEnumerable<object[]>

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableLong.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableLong.cs
@@ -38,14 +38,65 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void CustomErrorMessage(IEnumerable<long> input, long rangeFrom, long rangeTo)
+        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
         {
-            var message = "Incorrect Range";
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, message));
+            var input = new long[] { 0, 1, 99 };
+            long rangeFrom = 2;
+            long rangeTo = 1;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
             Assert.NotNull(exception);
-            Assert.NotEmpty(exception.Message);
-            Assert.Equal(message, exception.Message);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = new long[] { 0, 1, 99 };
+            long rangeFrom = 2;
+            long rangeTo = 1;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+        {
+            var input = new long[] { 0, 1, 99 };
+            long rangeFrom = 0;
+            long rangeTo = 1;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = new long[] { 0, 1, 99 };
+            long rangeFrom = 0;
+            long rangeTo = 1;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
 
         public class CorrectClassData : IEnumerable<object[]>

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableShort.cs
@@ -38,16 +38,66 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void CustomErrorMessage(IEnumerable<short> input, short rangeFrom, short rangeTo)
+        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
         {
-            var message = "Incorrect Range";
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, message));
+            var input = new short[] { 0, 1, 99 };
+            short rangeFrom = 2;
+            short rangeTo = 1;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
             Assert.NotNull(exception);
-            Assert.NotEmpty(exception.Message);
-            Assert.Equal(message, exception.Message);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
 
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = new short[] { 0, 1, 99 };
+            short rangeFrom = 2;
+            short rangeTo = 1;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+        {
+            var input = new short[] { 0, 1, 99 };
+            short rangeFrom = 0;
+            short rangeTo = 1;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = new short[] { 0, 1, 99 };
+            short rangeFrom = 0;
+            short rangeTo = 1;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
 
         public class CorrectClassData : IEnumerable<object[]>
         {

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableTimeSpan.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableTimeSpan.cs
@@ -55,21 +55,67 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void CustomErrorMessage(IEnumerable<int> input, int rangeFrom, int rangeTo)
+        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
         {
-            var message = "Incorrect Range";
-            var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+            var input = Enumerable.Range(0, 3).Select(i => TimeSpan.FromSeconds(i));
+            var rangeFrom = TimeSpan.FromSeconds(2);
+            var rangeTo = TimeSpan.FromSeconds(1);
 
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan, message));
-
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
             Assert.NotNull(exception);
-            Assert.NotEmpty(exception.Message);
-            Assert.Equal(message, exception.Message);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
-        
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = Enumerable.Range(0, 3).Select(i => TimeSpan.FromSeconds(i));
+            var rangeFrom = TimeSpan.FromSeconds(2);
+            var rangeTo = TimeSpan.FromSeconds(1);
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+        {
+            var input = Enumerable.Range(0, 3).Select(i => TimeSpan.FromSeconds(i));
+            var rangeFrom = TimeSpan.FromSeconds(0);
+            var rangeTo = TimeSpan.FromSeconds(1);
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+        {
+            var input = Enumerable.Range(0, 3).Select(i => TimeSpan.FromSeconds(i));
+            var rangeFrom = TimeSpan.FromSeconds(0);
+            var rangeTo = TimeSpan.FromSeconds(1);
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
         public class CorrectClassData : IEnumerable<object[]>
         {
             public IEnumerator<object[]> GetEnumerator()

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
@@ -46,13 +46,25 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Float range", "Float range")]
+        [InlineData("Float range", "Float range (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0f, "parameterName", 0.0f, 1.0f, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0f, expectedParamName, 0.0f, 1.0f, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForIComparable.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForIComparable.cs
@@ -52,13 +52,25 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Tuple range", "Tuple range")]
+        [InlineData("Tuple range", "Tuple range (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((1,2), "parameterName", (3,3), (9,9), customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((1, 2), expectedParamName, (3, 3), (9, 9), customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
@@ -46,13 +46,25 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Int range", "Int range")]
+        [InlineData("Int range", "Int range (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3, "parameterName", 0, 1, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3, expectedParamName, 0, 1, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInvalidInput.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInvalidInput.cs
@@ -32,14 +32,26 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "Input parameterName did not satisfy the options")]
-        [InlineData("Evaluation failed", "Evaluation failed")]
+        [InlineData(null, "Input parameterName did not satisfy the options (Parameter 'parameterName')")]
+        [InlineData("Evaluation failed", "Evaluation failed (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidInput(10, "parameterName", x => x > 20, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage + " (Parameter 'parameterName')", exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidInput(10, expectedParamName, x => x > 20, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
 
         // TODO: Test decimal types outside of ClassData

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
@@ -46,13 +46,25 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Short range", "Short range")]
+        [InlineData("Short range", "Short range (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((short) 3, "parameterName", (short) 0, (short) 1, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((short)3, expectedParamName, (short)0, (short)1, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForTimeSpan.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForTimeSpan.cs
@@ -62,18 +62,65 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "rangeFrom should be less or equal than rangeTo")]
-        [InlineData("Timespan range", "Timespan range")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
         {
             var inputTimeSpan = TimeSpan.FromSeconds(-1);
             var rangeFromTimeSpan = TimeSpan.FromSeconds(3);
             var rangeToTimeSpan = TimeSpan.FromSeconds(1);
 
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan, customMessage));
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, "parameterName", rangeFromTimeSpan, rangeToTimeSpan, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+        {
+            var inputTimeSpan = TimeSpan.FromSeconds(-1);
+            var rangeFromTimeSpan = TimeSpan.FromSeconds(3);
+            var rangeToTimeSpan = TimeSpan.FromSeconds(1);
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, expectedParamName, rangeFromTimeSpan, rangeToTimeSpan, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
+        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+        {
+            var inputTimeSpan = TimeSpan.FromSeconds(-1);
+            var rangeFromTimeSpan = TimeSpan.FromSeconds(0);
+            var rangeToTimeSpan = TimeSpan.FromSeconds(1);
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(inputTimeSpan, "parameterName", rangeFromTimeSpan, rangeToTimeSpan, customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+        {
+            var inputTimeSpan = TimeSpan.FromSeconds(-1);
+            var rangeFromTimeSpan = TimeSpan.FromSeconds(0);
+            var rangeToTimeSpan = TimeSpan.FromSeconds(1);
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(inputTimeSpan, expectedParamName, rangeFromTimeSpan, rangeToTimeSpan, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForUint.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForUint.cs
@@ -45,13 +45,25 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Uint range", "Uint range")]
+        [InlineData("Uint range", "Uint range (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((uint)3.0d, "parameterName", (uint)0.0d, (uint)1.0d, customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((uint)3.0d, expectedParamName, (uint)0.0d, (uint)1.0d, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
@@ -69,7 +69,7 @@ namespace GuardClauses.UnitTests
 
         [Theory]
         [InlineData(null, "Input date was out of range (Parameter 'date')")]
-        [InlineData("SQLDate range", "SQLDate range")]
+        [InlineData("SQLDate range", "SQLDate range (Parameter 'date')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-1);
@@ -78,6 +78,19 @@ namespace GuardClauses.UnitTests
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Please provide correct value")]
+        [InlineData("SomeParameter", null)]
+        [InlineData("SomeOtherParameter", "Value must be correct")]
+        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+        {
+            DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-1);
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, expectedParamName, customMessage));
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
 
         public static IEnumerable<object[]> GetSqlDateTimeTestVectors()


### PR DESCRIPTION
Fixes #168 

_What was done:_

- Added tests for almost all public API functions, that test whether the custom message is correct and whether ParamName property of the thrown Arg. Exception is set correctly.
- Fixed the missing ParamName in all relevant cases (in some cases, setting ParamName was not possible due to the construction signature of the exception, e.g. InvalidEnumArgumentException).
- Some of the pre-existing tests for checking custom messages are slightly adapted, to make them a bit more consistent across the board.

_Additional notes:_

- Code updates are kept at a minimum, only focusing on the ParamName issue (a separate discussion will be started for other potential improvements)
- More than a few unit tests have been added. This was done to ensure coverage regardless of the internal implementation. However, if there is too much redundancy, I could change that.
- Some of the tests for different overloads are separated (e.g. OutOfRange). But some are not (e.g. Negative) and all overloads are tested within one fixture or test. Adding new tests for ParamName and ErrorMessage, separated per overload would be cumbersome within one fixture. So those tests are implemented with a foreach loop testing multiple overloads. This is not great, and if the feedback is that this is not acceptable, I'd gladly change it.
- The pre-existing code style/organization has been followed both in the source and tests.

There are some additional improvements that were observed while working on this issue, that are not addressed with this pull request and could be discussed separately. Out of which one may be closely related to this:

- NullOrEmpty and NullOrWhiteSpace have a Null check within their implementation, as expected. However, custom message is not passed to this Null check and it is only passed to the empty/whitespace logic. 