### PR TITLE
Added CallerArgumentExpression and tests for more methods

### DIFF
--- a/src/GuardClauses/GuardAgainstNegativeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNegativeExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
-using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
+using System.Runtime.CompilerServices;
 using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
+using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace Ardalis.GuardClauses
 {
@@ -15,7 +16,17 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static int Negative([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static int Negative([JetBrainsNotNull] this IGuardClause guardClause, 
+            int input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static int Negative([JetBrainsNotNull] this IGuardClause guardClause,
+            int input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             return Negative<int>(guardClause, input, parameterName, message);
         }
@@ -29,7 +40,17 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static long Negative([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static long Negative([JetBrainsNotNull] this IGuardClause guardClause, 
+            long input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static long Negative([JetBrainsNotNull] this IGuardClause guardClause,
+            long input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             return Negative<long>(guardClause, input, parameterName, message);
         }
@@ -43,7 +64,17 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static decimal Negative([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static decimal Negative([JetBrainsNotNull] this IGuardClause guardClause, 
+            decimal input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static decimal Negative([JetBrainsNotNull] this IGuardClause guardClause,
+            decimal input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             return Negative<decimal>(guardClause, input, parameterName, message);
         }
@@ -57,7 +88,17 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static float Negative([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static float Negative([JetBrainsNotNull] this IGuardClause guardClause, 
+            float input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static float Negative([JetBrainsNotNull] this IGuardClause guardClause,
+            float input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             return Negative<float>(guardClause, input, parameterName, message);
         }
@@ -71,7 +112,17 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static double Negative([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static double Negative([JetBrainsNotNull] this IGuardClause guardClause, 
+            double input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static double Negative([JetBrainsNotNull] this IGuardClause guardClause,
+            double input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             return Negative<double>(guardClause, input, parameterName, message);
         }
@@ -85,7 +136,17 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static TimeSpan Negative([JetBrainsNotNull] this IGuardClause guardClause, TimeSpan input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static TimeSpan Negative([JetBrainsNotNull] this IGuardClause guardClause, 
+            TimeSpan input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static TimeSpan Negative([JetBrainsNotNull] this IGuardClause guardClause,
+            TimeSpan input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             return Negative<TimeSpan>(guardClause, input, parameterName, message);
         }
@@ -99,7 +160,17 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
-        private static T Negative<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null) where T : struct, IComparable
+#if NETSTANDARD || NETFRAMEWORK
+        private static T Negative<T>([JetBrainsNotNull] this IGuardClause guardClause, 
+            T input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null) where T : struct, IComparable
+#else
+        private static T Negative<T>([JetBrainsNotNull] this IGuardClause guardClause,
+            T input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null) where T : struct, IComparable
+#endif
         {
             if (input.CompareTo(default(T)) < 0)
             {
@@ -117,7 +188,17 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        public static int NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static int NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, 
+            int input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static int NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+            int input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             return NegativeOrZero<int>(guardClause, input, parameterName, message);
         }
@@ -130,7 +211,17 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        public static long NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static long NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, 
+            long input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static long NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+            long input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             return NegativeOrZero<long>(guardClause, input, parameterName, message);
         }
@@ -143,7 +234,17 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        public static decimal NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static decimal NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, 
+            decimal input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static decimal NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+            decimal input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             return NegativeOrZero<decimal>(guardClause, input, parameterName, message);
         }
@@ -156,7 +257,17 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        public static float NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static float NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, 
+            float input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static float NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+            float input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             return NegativeOrZero<float>(guardClause, input, parameterName, message);
         }
@@ -169,7 +280,17 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        public static double NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static double NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+            double input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static double NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+            double input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             return NegativeOrZero<double>(guardClause, input, parameterName, message);
         }
@@ -182,7 +303,17 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        public static TimeSpan NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, TimeSpan input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static TimeSpan NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, 
+            TimeSpan input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static TimeSpan NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+            TimeSpan input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             return NegativeOrZero<TimeSpan>(guardClause, input, parameterName, message);
         }
@@ -196,7 +327,17 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-        private static T NegativeOrZero<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null) where T : struct, IComparable
+#if NETSTANDARD || NETFRAMEWORK
+        private static T NegativeOrZero<T>([JetBrainsNotNull] this IGuardClause guardClause, 
+            T input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null) where T : struct, IComparable
+#else
+        private static T NegativeOrZero<T>([JetBrainsNotNull] this IGuardClause guardClause,
+            T input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null) where T : struct, IComparable
+#endif
         {
             if (input.CompareTo(default(T)) <= 0)
             {

--- a/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
@@ -1,7 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
 using JetBrainsNoEnumerationAttribute = JetBrains.Annotations.NoEnumerationAttribute;
 using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
-using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
 
 namespace Ardalis.GuardClauses
 {
@@ -17,13 +18,23 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <returns><paramref name="input" /> if the value is not null.</returns>
         /// <exception cref="NotFoundException"></exception>
-        public static T NotFound<T>([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] string key, [NotNull, JetBrainsNotNull][ValidatedNotNull][JetBrainsNoEnumeration] T input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName)
+#if NETSTANDARD || NETFRAMEWORK
+        public static T NotFound<T>([JetBrainsNotNull] this IGuardClause guardClause, 
+            [NotNull, JetBrainsNotNull][ValidatedNotNull] string key, 
+            [NotNull, JetBrainsNotNull][ValidatedNotNull][JetBrainsNoEnumeration] T input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName)
+#else
+        public static T NotFound<T>([JetBrainsNotNull] this IGuardClause guardClause,
+            [NotNull, JetBrainsNotNull][ValidatedNotNull] string key,
+            [NotNull, JetBrainsNotNull][ValidatedNotNull][JetBrainsNoEnumeration] T input,
+            [JetBrainsNotNull][CallerArgumentExpression("input")] string? parameterName = null)
+#endif
         {
             guardClause.NullOrEmpty(key, nameof(key));
 
             if (input is null)
             {
-                throw new NotFoundException(key, parameterName);
+                throw new NotFoundException(key, parameterName!);
             }
 
             return input;
@@ -40,14 +51,24 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <returns><paramref name="input" /> if the value is not null.</returns>
         /// <exception cref="NotFoundException"></exception>
-        public static T NotFound<TKey, T>([JetBrainsNotNull] this IGuardClause guardClause, [NotNull, JetBrainsNotNull][ValidatedNotNull] TKey key, [NotNull, JetBrainsNotNull][ValidatedNotNull][JetBrainsNoEnumeration] T input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName) where TKey : struct
+#if NETSTANDARD || NETFRAMEWORK
+        public static T NotFound<TKey, T>([JetBrainsNotNull] this IGuardClause guardClause, 
+            [NotNull, JetBrainsNotNull][ValidatedNotNull] TKey key, 
+            [NotNull, JetBrainsNotNull][ValidatedNotNull][JetBrainsNoEnumeration] T input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName) where TKey : struct
+#else
+        public static T NotFound<TKey, T>([JetBrainsNotNull] this IGuardClause guardClause,
+            [NotNull, JetBrainsNotNull][ValidatedNotNull] TKey key,
+            [NotNull, JetBrainsNotNull][ValidatedNotNull][JetBrainsNoEnumeration] T input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null) where TKey : struct
+#endif
         {
             guardClause.Null(key, nameof(key));
 
             if (input is null)
             {
                 // TODO: Can we safely consider that ToString() won't return null for struct?
-                throw new NotFoundException(key.ToString()!, parameterName);
+                throw new NotFoundException(key.ToString()!, parameterName!);
             }
 
             return input;

--- a/src/GuardClauses/GuardAgainstNullExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNullExtensions.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
 using JetBrainsNoEnumerationAttribute = JetBrains.Annotations.NoEnumerationAttribute;
 using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
-using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
 
 namespace Ardalis.GuardClauses
 {
@@ -61,10 +61,17 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not an empty string or null.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
+#if NETSTANDARD || NETFRAMEWORK
         public static string NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause,
             [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input,
             [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName,
             string? message = null)
+#else
+        public static string NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause,
+            [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             Guard.Against.Null(input, parameterName, message);
             if (input == string.Empty)
@@ -86,10 +93,17 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not an empty guid or null.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
+#if NETSTANDARD || NETFRAMEWORK
         public static Guid NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause,
             [NotNull, JetBrainsNotNull][ValidatedNotNull] Guid? input,
             [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName,
             string? message = null)
+#else
+        public static Guid NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause,
+            [NotNull, JetBrainsNotNull][ValidatedNotNull] Guid? input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             Guard.Against.Null(input, parameterName, message);
             if (input == Guid.Empty)
@@ -111,10 +125,17 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not an empty enumerable or null.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
+#if NETSTANDARD || NETFRAMEWORK
         public static IEnumerable<T> NullOrEmpty<T>([JetBrainsNotNull] this IGuardClause guardClause,
             [NotNull, JetBrainsNotNull][ValidatedNotNull] IEnumerable<T>? input,
             [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName,
             string? message = null)
+#else
+        public static IEnumerable<T> NullOrEmpty<T>([JetBrainsNotNull] this IGuardClause guardClause,
+            [NotNull, JetBrainsNotNull][ValidatedNotNull] IEnumerable<T>? input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             Guard.Against.Null(input, parameterName, message);
             if (!input.Any())
@@ -136,10 +157,17 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not an empty or whitespace string.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
+#if NETSTANDARD || NETFRAMEWORK
         public static string NullOrWhiteSpace([JetBrainsNotNull] this IGuardClause guardClause,
             [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input,
             [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName,
             string? message = null)
+#else
+        public static string NullOrWhiteSpace([JetBrainsNotNull] this IGuardClause guardClause,
+            [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             Guard.Against.NullOrEmpty(input, parameterName, message);
             if (String.IsNullOrWhiteSpace(input))
@@ -159,7 +187,17 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not default for that type.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static T Default<T>([JetBrainsNotNull] this IGuardClause guardClause, [AllowNull, NotNull, JetBrainsNotNull][JetBrainsNoEnumeration] T input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static T Default<T>([JetBrainsNotNull] this IGuardClause guardClause, 
+            [AllowNull, NotNull, JetBrainsNotNull][JetBrainsNoEnumeration] T input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static T Default<T>([JetBrainsNotNull] this IGuardClause guardClause,
+            [AllowNull, NotNull, JetBrainsNotNull][JetBrainsNoEnumeration] T input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             if (EqualityComparer<T>.Default.Equals(input, default(T)!) || input is null)
             {

--- a/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
@@ -2,8 +2,9 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
+using System.Runtime.CompilerServices;
 using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
+using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace Ardalis.GuardClauses
 {
@@ -19,7 +20,17 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="InvalidEnumArgumentException"></exception>
-        public static int EnumOutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null) where T : struct, Enum
+#if NETSTANDARD || NETFRAMEWORK
+        public static int EnumOutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, 
+            int input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null) where T : struct, Enum
+#else
+        public static int EnumOutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause,
+            int input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null) where T : struct, Enum
+#endif
         {
             if (!Enum.IsDefined(typeof(T), input))
             {
@@ -43,7 +54,17 @@ namespace Ardalis.GuardClauses
         /// /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="InvalidEnumArgumentException"></exception>
-        public static T EnumOutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null) where T : struct, Enum
+#if NETSTANDARD || NETFRAMEWORK
+        public static T EnumOutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, 
+            T input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null) where T : struct, Enum
+#else
+        public static T EnumOutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause,
+            T input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null) where T : struct, Enum
+#endif
         {
             if (!Enum.IsDefined(typeof(T), input))
             {
@@ -96,16 +117,23 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
+#if NETSTANDARD || NETFRAMEWORK
         public static DateTime OutOfSQLDateRange([JetBrainsNotNull] this IGuardClause guardClause,
             DateTime input,
             [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName,
             string? message = null)
+#else
+        public static DateTime OutOfSQLDateRange([JetBrainsNotNull] this IGuardClause guardClause,
+            DateTime input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
             // System.Data is unavailable in .NET Standard so we can't use SqlDateTime.
             const long sqlMinDateTicks = 552877920000000000;
             const long sqlMaxDateTicks = 3155378975999970000;
 
-            return OutOfRange<DateTime>(guardClause, input, parameterName, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks), message);
+            return OutOfRange<DateTime>(guardClause, input, parameterName!, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks), message);
         }
 
         /// <summary>

--- a/src/GuardClauses/GuardAgainstZeroExtensions.cs
+++ b/src/GuardClauses/GuardAgainstZeroExtensions.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
+using System.Runtime.CompilerServices;
 using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
+using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace Ardalis.GuardClauses
 {
@@ -16,9 +17,19 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static int Zero([JetBrainsNotNull] this IGuardClause guardClause, int input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static int Zero([JetBrainsNotNull] this IGuardClause guardClause, 
+            int input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static int Zero([JetBrainsNotNull] this IGuardClause guardClause,
+            int input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
-            return Zero<int>(guardClause, input, parameterName, message);
+            return Zero<int>(guardClause, input, parameterName!, message);
         }
 
         /// <summary>
@@ -30,9 +41,19 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static long Zero([JetBrainsNotNull] this IGuardClause guardClause, long input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static long Zero([JetBrainsNotNull] this IGuardClause guardClause, 
+            long input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static long Zero([JetBrainsNotNull] this IGuardClause guardClause,
+            long input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
-            return Zero<long>(guardClause, input, parameterName, message);
+            return Zero<long>(guardClause, input, parameterName!, message);
         }
 
         /// <summary>
@@ -44,9 +65,19 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static decimal Zero([JetBrainsNotNull] this IGuardClause guardClause, decimal input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static decimal Zero([JetBrainsNotNull] this IGuardClause guardClause, 
+            decimal input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static decimal Zero([JetBrainsNotNull] this IGuardClause guardClause,
+            decimal input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
-            return Zero<decimal>(guardClause, input, parameterName, message);
+            return Zero<decimal>(guardClause, input, parameterName!, message);
         }
 
         /// <summary>
@@ -58,9 +89,19 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static float Zero([JetBrainsNotNull] this IGuardClause guardClause, float input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static float Zero([JetBrainsNotNull] this IGuardClause guardClause, 
+            float input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static float Zero([JetBrainsNotNull] this IGuardClause guardClause,
+            float input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
-            return Zero<float>(guardClause, input, parameterName, message);
+            return Zero<float>(guardClause, input, parameterName!, message);
         }
 
         /// <summary>
@@ -72,9 +113,19 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static double Zero([JetBrainsNotNull] this IGuardClause guardClause, double input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null)
+#if NETSTANDARD || NETFRAMEWORK
+        public static double Zero([JetBrainsNotNull] this IGuardClause guardClause, 
+            double input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string? message = null)
+#else
+        public static double Zero([JetBrainsNotNull] this IGuardClause guardClause,
+            double input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            string? message = null)
+#endif
         {
-            return Zero<double>(guardClause, input, parameterName, message);
+            return Zero<double>(guardClause, input, parameterName!, message);
         }
 
         /// <summary>
@@ -85,9 +136,17 @@ namespace Ardalis.GuardClauses
         /// <param name="parameterName"></param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static TimeSpan Zero([JetBrainsNotNull] this IGuardClause guardClause, TimeSpan input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName)
+#if NETSTANDARD || NETFRAMEWORK
+        public static TimeSpan Zero([JetBrainsNotNull] this IGuardClause guardClause, 
+            TimeSpan input, 
+            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName)
+#else
+        public static TimeSpan Zero([JetBrainsNotNull] this IGuardClause guardClause,
+            TimeSpan input,
+            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null)
+#endif
         {
-            return Zero<TimeSpan>(guardClause, input, parameterName);
+            return Zero<TimeSpan>(guardClause, input, parameterName!);
         }
 
         /// <summary>

--- a/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
@@ -1,6 +1,6 @@
-﻿using Ardalis.GuardClauses;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using Ardalis.GuardClauses;
 using Xunit;
 
 namespace GuardClauses.UnitTests
@@ -41,6 +41,18 @@ namespace GuardClauses.UnitTests
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
         {
             var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Default(default(string), "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Parameter [xyz] is default value for type String (Parameter 'xyz')")]
+        [InlineData("Please provide correct value", "Please provide correct value (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided(string customMessage, string expectedMessage)
+        {
+            var xyz = default(string);
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Default(xyz, message: customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);

--- a/test/GuardClauses.UnitTests/GuardAgainstFooExtension.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstFooExtension.cs
@@ -18,5 +18,17 @@ namespace GuardClauses.UnitTests
             Guard.Against.Foo("anythingElse", "aParameterName");
             //Guard.Against.Foo(null, "aParameterName");
         }
+
+        [Fact]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided()
+        {
+            string? xyz = "foo";
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Foo(xyz));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Contains($"Should not have been foo! (Parameter '{nameof(xyz)}')", exception.Message);
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
@@ -17,7 +17,7 @@ namespace GuardClauses.UnitTests
             Guard.Against.Negative(0.0, "doubleZero");
             Guard.Against.Negative(TimeSpan.Zero, "timespanZero");
         }
-        
+
         [Fact]
         public void DoesNothingGivenPositiveValue()
         {
@@ -28,7 +28,7 @@ namespace GuardClauses.UnitTests
             Guard.Against.Negative(1.0, "doubleZero");
             Guard.Against.Negative(TimeSpan.FromSeconds(1), "timespanZero");
         }
-        
+
         [Fact]
         public void ThrowsGivenNegativeIntValue()
         {
@@ -105,6 +105,90 @@ namespace GuardClauses.UnitTests
         {
             Assert.Equal(TimeSpan.Zero, Guard.Against.Negative(TimeSpan.Zero, "timespanZero"));
             Assert.Equal(TimeSpan.FromSeconds(1), Guard.Against.Negative(TimeSpan.FromSeconds(1), "timespanOne"));
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
+        [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenIntValue(string customMessage, string expectedMessage)
+        {
+            var xyz = -1;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
+        [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenLongValue(string customMessage, string expectedMessage)
+        {
+            var xyz = -1L;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
+        [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDecimalValue(string customMessage, string expectedMessage)
+        {
+            var xyz = -1.0M;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
+        [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenFloatValue(string customMessage, string expectedMessage)
+        {
+            var xyz = -1.0f;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
+        [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDoubleValue(string customMessage, string expectedMessage)
+        {
+            var xyz = -1.0;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
+        [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenTimeSpanValue(string customMessage, string expectedMessage)
+        {
+            var xyz = TimeSpan.FromSeconds(-1);
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
@@ -1,7 +1,6 @@
-﻿using Ardalis.GuardClauses;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using Ardalis.GuardClauses;
 using Xunit;
 
 namespace GuardClauses.UnitTests
@@ -9,7 +8,7 @@ namespace GuardClauses.UnitTests
     public class GuardAgainstNegativeOrZero
     {
         [Fact]
-        public void DoesNothingGivenPositiveValue() 
+        public void DoesNothingGivenPositiveValue()
         {
             Guard.Against.NegativeOrZero(1, "intPositive");
             Guard.Against.NegativeOrZero(1L, "longPositive");
@@ -107,6 +106,92 @@ namespace GuardClauses.UnitTests
             Assert.Equal(1.0f, Guard.Against.NegativeOrZero(1.0f, "floatPositive"));
             Assert.Equal(1.0, Guard.Against.NegativeOrZero(1.0, "doublePositive"));
             Assert.Equal(TimeSpan.FromSeconds(1), Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(1), "timespanPositive"));
+        }
+
+        [Theory]
+        [InlineData(-1, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+        [InlineData(-1, "Must be positive", "Must be positive (Parameter 'xyz')")]
+        [InlineData(0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+        [InlineData(0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenIntValue(int xyz, string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(-1L, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+        [InlineData(-1L, "Must be positive", "Must be positive (Parameter 'xyz')")]
+        [InlineData(0L, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+        [InlineData(0L, "Must be positive", "Must be positive (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenLongValue(long xyz, string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(-1.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+        [InlineData(-1.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+        [InlineData(0.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+        [InlineData(0.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDecimalValue(decimal xyz, string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(-1.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+        [InlineData(-1.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+        [InlineData(0.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+        [InlineData(0.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenFloatValue(float xyz, string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(-1.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+        [InlineData(-1.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+        [InlineData(0.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+        [InlineData(0.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDoubleValue(double xyz, string customMessage, string expectedMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(-1.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+        [InlineData(-1.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+        [InlineData(0.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+        [InlineData(0.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenTimeSpanValue(double change, string customMessage, string expectedMessage)
+        {
+            var xyz = TimeSpan.FromSeconds(change);
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstNotFound.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNotFound.cs
@@ -1,5 +1,5 @@
-﻿using Ardalis.GuardClauses;
-using System;
+﻿using System;
+using Ardalis.GuardClauses;
 using Xunit;
 
 namespace GuardClauses.UnitTests
@@ -31,12 +31,37 @@ namespace GuardClauses.UnitTests
 
             var guid = Guid.Empty;
             Assert.Equal(guid, Guard.Against.NotFound(1, guid, "guid"));
-            
+
             var now = DateTime.Now;
             Assert.Equal(now, Guard.Against.NotFound(1, now, "datetime"));
 
             var obj = new Object();
             Assert.Equal(obj, Guard.Against.NotFound(1, obj, "object"));
+        }
+
+        [Fact]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenStringValue()
+        {
+            string? xyz = null;
+            var key = "mykey";
+
+            var exception = Assert.Throws<NotFoundException>(() => Guard.Against.NotFound(key, xyz));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Contains($"Queried object {nameof(xyz)} was not found, Key: {key}", exception.Message);
+
+            //Assert.Equal("", Guard.Against.NotFound("mykey", "", "string"));
+            //Assert.Equal(1, Guard.Against.NotFound(1, 1, "int"));
+
+            //var guid = Guid.Empty;
+            //Assert.Equal(guid, Guard.Against.NotFound(1, guid, "guid"));
+
+            //var now = DateTime.Now;
+            //Assert.Equal(now, Guard.Against.NotFound(1, now, "datetime"));
+
+            //var obj = new Object();
+            //Assert.Equal(obj, Guard.Against.NotFound(1, obj, "object"));
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
@@ -1,7 +1,7 @@
-﻿using Ardalis.GuardClauses;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Ardalis.GuardClauses;
 using Xunit;
 
 namespace GuardClauses.UnitTests
@@ -24,8 +24,8 @@ namespace GuardClauses.UnitTests
         [Fact]
         public void DoesNothingGivenNonEmptyEnumerable()
         {
-            Guard.Against.NullOrEmpty(new [] { "foo", "bar" }, "stringArray");
-            Guard.Against.NullOrEmpty(new [] { 1, 2 }, "intArray");
+            Guard.Against.NullOrEmpty(new[] { "foo", "bar" }, "stringArray");
+            Guard.Against.NullOrEmpty(new[] { 1, 2 }, "intArray");
         }
 
         [Fact]
@@ -66,11 +66,53 @@ namespace GuardClauses.UnitTests
             Assert.Equal("a", Guard.Against.NullOrEmpty("a", "string"));
             Assert.Equal("1", Guard.Against.NullOrEmpty("1", "aNumericString"));
 
-            var collection1 = new[] {"foo", "bar"};
+            var collection1 = new[] { "foo", "bar" };
             Assert.Equal(collection1, Guard.Against.NullOrEmpty(collection1, "stringArray"));
 
-            var collection2 = new[] {1, 2};
+            var collection2 = new[] { 1, 2 };
             Assert.Equal(collection2, Guard.Against.NullOrEmpty(collection2, "intArray"));
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz was empty. (Parameter 'xyz')")]
+        [InlineData("Value is empty", "Value is empty (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenStringValue(string customMessage, string expectedMessage)
+        {
+            string xyz = string.Empty;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Contains(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz was empty. (Parameter 'xyz')")]
+        [InlineData("Value is empty", "Value is empty (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenGuidValue(string customMessage, string expectedMessage)
+        {
+            Guid xyz = Guid.Empty;
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Contains(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz was empty. (Parameter 'xyz')")]
+        [InlineData("Value is empty", "Value is empty (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenIEnumerableValue(string customMessage, string expectedMessage)
+        {
+            IEnumerable<string> xyz = Enumerable.Empty<string>();
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Contains(expectedMessage, exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -1,5 +1,5 @@
-﻿using Ardalis.GuardClauses;
-using System;
+﻿using System;
+using Ardalis.GuardClauses;
 using Xunit;
 
 namespace GuardClauses.UnitTests
@@ -68,6 +68,18 @@ namespace GuardClauses.UnitTests
         {
             string? nullString = null;
             var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(nullString, "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Value cannot be null. (Parameter 'xyz')")]
+        [InlineData("Value is null", "Value is null (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided(string customMessage, string expectedMessage)
+        {
+            string? xyz = null;
+            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(xyz, message: customMessage));
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
@@ -1,5 +1,5 @@
-﻿using Ardalis.GuardClauses;
-using System.ComponentModel;
+﻿using System.ComponentModel;
+using Ardalis.GuardClauses;
 using Xunit;
 
 namespace GuardClauses.UnitTests
@@ -17,7 +17,7 @@ namespace GuardClauses.UnitTests
         {
             Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue));
         }
-        
+
 
         [Theory]
         [InlineData(-1)]
@@ -43,9 +43,9 @@ namespace GuardClauses.UnitTests
 
 
         [Theory]
-        [InlineData((TestEnum) (-1))]
-        [InlineData((TestEnum) 6)]
-        [InlineData((TestEnum) 10)]
+        [InlineData((TestEnum)(-1))]
+        [InlineData((TestEnum)6)]
+        [InlineData((TestEnum)10)]
         public void ThrowsGivenOutOfRangeEnum(TestEnum enumValue)
         {
             var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.EnumOutOfRange(enumValue, nameof(enumValue)));
@@ -85,6 +85,20 @@ namespace GuardClauses.UnitTests
         {
             var exception = Assert.Throws<InvalidEnumArgumentException>(
                 () => Guard.Against.EnumOutOfRange((TestEnum)99, "parameterName", customMessage));
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "The value of argument 'xyz' (99) is invalid for Enum type 'TestEnum'. (Parameter 'xyz')")]
+        [InlineData("Invalid enum value", "Invalid enum value")]
+        public void ErrorMessageMatchesExpectedWhenInputIsEnumAndParamNameNotExplicitlyProvided(string customMessage, string expectedMessage)
+        {
+            var xyz = (TestEnum)99;
+            var exception = Assert.Throws<InvalidEnumArgumentException>(
+                () => Guard.Against.EnumOutOfRange(xyz, message: customMessage));
+
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
@@ -1,7 +1,7 @@
-﻿using Ardalis.GuardClauses;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data.SqlTypes;
+using Ardalis.GuardClauses;
 using Xunit;
 
 namespace GuardClauses.UnitTests
@@ -81,6 +81,19 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [InlineData(null, "Input date was out of range (Parameter 'date')")]
+        [InlineData("SQLDate range", "SQLDate range (Parameter 'date')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided(string customMessage, string expectedMessage)
+        {
+            DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-1);
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
         [InlineData(null, null)]
         [InlineData(null, "Please provide correct value")]
         [InlineData("SomeParameter", null)]
@@ -101,11 +114,11 @@ namespace GuardClauses.UnitTests
             var min = SqlDateTime.MinValue.Value;
             var max = SqlDateTime.MaxValue.Value;
 
-            yield return new object[] {now, "now", now};
-            yield return new object[] {utc, "utc", utc};
-            yield return new object[] {yesterday, "yesterday", yesterday};
-            yield return new object[] {min, "min", min};
-            yield return new object[] {max, "max", max};
+            yield return new object[] { now, "now", now };
+            yield return new object[] { utc, "utc", utc };
+            yield return new object[] { yesterday, "yesterday", yesterday };
+            yield return new object[] { min, "min", min };
+            yield return new object[] { max, "max", max };
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstZero.cs
@@ -1,6 +1,6 @@
-﻿using Ardalis.GuardClauses;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using Ardalis.GuardClauses;
 using Xunit;
 
 namespace GuardClauses.UnitTests
@@ -114,7 +114,7 @@ namespace GuardClauses.UnitTests
         [InlineData(null, "Required input parameterName cannot be zero. (Parameter 'parameterName')")]
         [InlineData("Value is ZERO", "Value is ZERO (Parameter 'parameterName')")]
         public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        { 
+        {
             var clausesToEvaluate = new List<Action>
             {
                 () => Guard.Against.Zero(0, "parameterName", customMessage),
@@ -132,6 +132,71 @@ namespace GuardClauses.UnitTests
                 Assert.NotNull(exception.Message);
                 Assert.Equal(expectedMessage, exception.Message);
             }
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
+        [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenIntValue(string customMessage, string expectedMessage)
+        {
+            var xyz = 0;
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
+        [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenLongValue(string customMessage, string expectedMessage)
+        {
+            var xyz = 0L;
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
+        [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDecimalValue(string customMessage, string expectedMessage)
+        {
+            var xyz = 0.0M;
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
+        [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenFloatValue(string customMessage, string expectedMessage)
+        {
+            var xyz = 0.0f;
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
+        [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
+        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDoubleValue(string customMessage, string expectedMessage)
+        {
+            var xyz = 0.0;
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
+
+            Assert.NotNull(exception);
+            Assert.NotNull(exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/NamespaceSeparate/ExtendingGuard.cs
+++ b/test/GuardClauses.UnitTests/NamespaceSeparate/ExtendingGuard.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 // By using the same namespace, the required using for Ardalis.GuardClauses will include custom guards regardless of location.
 namespace Ardalis.GuardClauses
@@ -8,7 +9,11 @@ namespace Ardalis.GuardClauses
     /// </summary>
     public static class FooGuard
     {
+#if NETSTANDARD || NETFRAMEWORK
         public static void Foo(this IGuardClause guardClause, string input, string parameterName)
+#else
+        public static void Foo(this IGuardClause guardClause, string input, [CallerArgumentExpression("input")] string? parameterName = null)
+#endif
         {
             if (input?.ToLower() == "foo")
                 throw new ArgumentException("Should not have been foo!", parameterName);


### PR DESCRIPTION
Following on from #149 

I have added the attributes to a number of the other methods. There are some I have left out because they would require swapping parameter orders around and I wasn't sure how you wanted to proceed with those? The methods I skipped for this PR are:

*GuardAgainstInvalidFormExtensions.cs*
```
public static string InvalidFormat(...)
public static T InvalidInput<T>(...)
```

*GuardAgainstOutOfRangeExtensions.cs*
```
public static IEnumerable<T> OutOfRange<T>(...)
public static T OutOfRange<T>(...)
```

---

There are also a few places where I have added a `!` to stop VS moaning about null references because they relate to the `parameterName` parameter which will be given a value by the compiler so they can't be null. If my understanding of this is wrong let me know and I'll make the changes I need to. These methods are:

*GuardAgainstNotFoundExtensions.cs*
```
public static T NotFound<T>(...)
public static T NotFound<TKey, T>(...)
```

*GuardAgainstOutOfRangeExtensions.cs*
```
public static DateTime OutOfSQLDateRange(...)
```

*GuardAgainstZeroExtensions.cs*
```
public static int Zero(...)
public static long Zero(...)
public static decimal Zero(...)
public static float Zero(...)
public static double Zero(...)
public static TimeSpan Zero(...)
```

