### PR TITLE
Embed license in nuget package 

### DIFF
--- a/src/GuardClauses/GuardClauses.csproj
+++ b/src/GuardClauses/GuardClauses.csproj
@@ -1,5 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <PropertyGroup>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
+</ItemGroup>
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451;net60</TargetFrameworks>
     <PackageId>Ardalis.GuardClauses</PackageId>


### PR DESCRIPTION
Embed license in nuget package so that tools like https://fossa.com/ can detect the project's license when scanning dependencies in downstream applications.
Resolves #209 