### PR TITLE
Remove JetBrains Annotations

### DIFF
--- a/src/GuardClauses/Guard.cs
+++ b/src/GuardClauses/Guard.cs
@@ -1,6 +1,4 @@
-﻿using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
-
-namespace Ardalis.GuardClauses
+﻿namespace Ardalis.GuardClauses
 {
     /// <summary>
     /// Simple interface to provide a generic mechanism to build guard clause extension methods from.
@@ -18,7 +16,7 @@ namespace Ardalis.GuardClauses
         /// <summary>
         /// An entry point to a set of Guard Clauses.
         /// </summary>
-        [JetBrainsNotNull] public static IGuardClause Against { get; } = new Guard();
+        public static IGuardClause Against { get; } = new Guard();
 
         private Guard() { }
     }

--- a/src/GuardClauses/GuardAgainstExpressionExtensions.cs
+++ b/src/GuardClauses/GuardAgainstExpressionExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace Ardalis.GuardClauses
 {
@@ -15,7 +14,7 @@ namespace Ardalis.GuardClauses
         /// <param name="message"></param>
         /// <returns><paramref name="input"/> if the <paramref name="func"/> evaluates to true </returns>
         /// <exception cref="ArgumentException"></exception>
-        public static T AgainstExpression<T>([JetBrainsNotNull] this IGuardClause guardClause, [JetBrainsNotNull] Func<T, bool> func, T input, string message) where T : struct
+        public static T AgainstExpression<T>(this IGuardClause guardClause, Func<T, bool> func, T input, string message) where T : struct
         {
             if (!func(input))
             {

--- a/src/GuardClauses/GuardAgainstInvalidFormatExtensions.cs
+++ b/src/GuardClauses/GuardAgainstInvalidFormatExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Text.RegularExpressions;
-using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
-using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
-using JetBrainsRegexPattern = JetBrains.Annotations.RegexPatternAttribute;
 
 namespace Ardalis.GuardClauses
 {
@@ -18,10 +15,10 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns></returns>
         /// <exception cref="ArgumentException"></exception>
-        public static string InvalidFormat([JetBrainsNotNull] this IGuardClause guardClause,
-            [JetBrainsNotNull] string input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName,
-            [JetBrainsNotNull][JetBrainsRegexPattern] string regexPattern,
+        public static string InvalidFormat(this IGuardClause guardClause,
+            string input,
+            string parameterName,
+            string regexPattern,
             string? message = null)
         {
             var m = Regex.Match(input, regexPattern);
@@ -44,7 +41,7 @@ namespace Ardalis.GuardClauses
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         /// <exception cref="ArgumentException"></exception>
-        public static T InvalidInput<T>([JetBrainsNotNull] this IGuardClause guardClause, [JetBrainsNotNull] T input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, Func<T, bool> predicate, string? message = null)
+        public static T InvalidInput<T>(this IGuardClause guardClause, T input, string parameterName, Func<T, bool> predicate, string? message = null)
         {
             if (!predicate(input))
             {

--- a/src/GuardClauses/GuardAgainstNegativeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNegativeExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
-using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
-using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace Ardalis.GuardClauses
 {
@@ -17,14 +15,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static int Negative([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static int Negative(this IGuardClause guardClause, 
             int input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static int Negative([JetBrainsNotNull] this IGuardClause guardClause,
+        public static int Negative(this IGuardClause guardClause,
             int input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -41,14 +39,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static long Negative([JetBrainsNotNull] this IGuardClause guardClause, 
-            long input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+        public static long Negative(this IGuardClause guardClause,
+            long input,
+            string parameterName,
             string? message = null)
 #else
-        public static long Negative([JetBrainsNotNull] this IGuardClause guardClause,
+        public static long Negative(this IGuardClause guardClause,
             long input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -65,14 +63,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static decimal Negative([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static decimal Negative(this IGuardClause guardClause, 
             decimal input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static decimal Negative([JetBrainsNotNull] this IGuardClause guardClause,
+        public static decimal Negative(this IGuardClause guardClause,
             decimal input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -89,14 +87,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static float Negative([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static float Negative(IGuardClause guardClause, 
             float input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static float Negative([JetBrainsNotNull] this IGuardClause guardClause,
+        public static float Negative(this IGuardClause guardClause,
             float input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -113,14 +111,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static double Negative([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static double Negative(this IGuardClause guardClause, 
             double input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static double Negative([JetBrainsNotNull] this IGuardClause guardClause,
+        public static double Negative(this IGuardClause guardClause,
             double input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -137,14 +135,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static TimeSpan Negative([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static TimeSpan Negative(this IGuardClause guardClause, 
             TimeSpan input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static TimeSpan Negative([JetBrainsNotNull] this IGuardClause guardClause,
+        public static TimeSpan Negative(this IGuardClause guardClause,
             TimeSpan input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -161,14 +159,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        private static T Negative<T>([JetBrainsNotNull] this IGuardClause guardClause, 
+        private static T Negative<T>(this IGuardClause guardClause, 
             T input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null) where T : struct, IComparable
 #else
-        private static T Negative<T>([JetBrainsNotNull] this IGuardClause guardClause,
+        private static T Negative<T>(this IGuardClause guardClause,
             T input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null) where T : struct, IComparable
 #endif
         {
@@ -189,14 +187,14 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        public static int NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static int NegativeOrZero(this IGuardClause guardClause, 
             int input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static int NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static int NegativeOrZero(this IGuardClause guardClause,
             int input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -212,14 +210,14 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        public static long NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static long NegativeOrZero(this IGuardClause guardClause, 
             long input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static long NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static long NegativeOrZero(this IGuardClause guardClause,
             long input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -235,14 +233,14 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        public static decimal NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static decimal NegativeOrZero(this IGuardClause guardClause, 
             decimal input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static decimal NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static decimal NegativeOrZero(this IGuardClause guardClause,
             decimal input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -258,14 +256,14 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        public static float NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static float NegativeOrZero(this IGuardClause guardClause, 
             float input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static float NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static float NegativeOrZero(this IGuardClause guardClause,
             float input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -281,14 +279,14 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        public static double NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static double NegativeOrZero(this IGuardClause guardClause,
             double input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static double NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static double NegativeOrZero(this IGuardClause guardClause,
             double input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -304,14 +302,14 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        public static TimeSpan NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static TimeSpan NegativeOrZero(this IGuardClause guardClause, 
             TimeSpan input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static TimeSpan NegativeOrZero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static TimeSpan NegativeOrZero(this IGuardClause guardClause,
             TimeSpan input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -328,14 +326,14 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        private static T NegativeOrZero<T>([JetBrainsNotNull] this IGuardClause guardClause, 
+        private static T NegativeOrZero<T>(this IGuardClause guardClause, 
             T input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null) where T : struct, IComparable
 #else
-        private static T NegativeOrZero<T>([JetBrainsNotNull] this IGuardClause guardClause,
+        private static T NegativeOrZero<T>(this IGuardClause guardClause,
             T input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null) where T : struct, IComparable
 #endif
         {

--- a/src/GuardClauses/GuardAgainstNegativeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNegativeExtensions.cs
@@ -15,9 +15,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static int Negative(this IGuardClause guardClause, 
-            int input, 
-            string parameterName, 
+        public static int Negative(this IGuardClause guardClause,
+            int input,
+            string parameterName,
             string? message = null)
 #else
         public static int Negative(this IGuardClause guardClause,
@@ -63,9 +63,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static decimal Negative(this IGuardClause guardClause, 
-            decimal input, 
-            string parameterName, 
+        public static decimal Negative(this IGuardClause guardClause,
+            decimal input,
+            string parameterName,
             string? message = null)
 #else
         public static decimal Negative(this IGuardClause guardClause,
@@ -87,9 +87,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static float Negative(IGuardClause guardClause, 
-            float input, 
-            string parameterName, 
+        public static float Negative(IGuardClause guardClause,
+            float input,
+            string parameterName,
             string? message = null)
 #else
         public static float Negative(this IGuardClause guardClause,
@@ -111,9 +111,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static double Negative(this IGuardClause guardClause, 
-            double input, 
-            string parameterName, 
+        public static double Negative(this IGuardClause guardClause,
+            double input,
+            string parameterName,
             string? message = null)
 #else
         public static double Negative(this IGuardClause guardClause,
@@ -135,9 +135,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static TimeSpan Negative(this IGuardClause guardClause, 
-            TimeSpan input, 
-            string parameterName, 
+        public static TimeSpan Negative(this IGuardClause guardClause,
+            TimeSpan input,
+            string parameterName,
             string? message = null)
 #else
         public static TimeSpan Negative(this IGuardClause guardClause,
@@ -159,9 +159,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        private static T Negative<T>(this IGuardClause guardClause, 
-            T input, 
-            string parameterName, 
+        private static T Negative<T>(this IGuardClause guardClause,
+            T input,
+            string parameterName,
             string? message = null) where T : struct, IComparable
 #else
         private static T Negative<T>(this IGuardClause guardClause,
@@ -187,9 +187,9 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        public static int NegativeOrZero(this IGuardClause guardClause, 
-            int input, 
-            string parameterName, 
+        public static int NegativeOrZero(this IGuardClause guardClause,
+            int input,
+            string parameterName,
             string? message = null)
 #else
         public static int NegativeOrZero(this IGuardClause guardClause,
@@ -210,9 +210,9 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        public static long NegativeOrZero(this IGuardClause guardClause, 
-            long input, 
-            string parameterName, 
+        public static long NegativeOrZero(this IGuardClause guardClause,
+            long input,
+            string parameterName,
             string? message = null)
 #else
         public static long NegativeOrZero(this IGuardClause guardClause,
@@ -233,9 +233,9 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        public static decimal NegativeOrZero(this IGuardClause guardClause, 
-            decimal input, 
-            string parameterName, 
+        public static decimal NegativeOrZero(this IGuardClause guardClause,
+            decimal input,
+            string parameterName,
             string? message = null)
 #else
         public static decimal NegativeOrZero(this IGuardClause guardClause,
@@ -256,9 +256,9 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        public static float NegativeOrZero(this IGuardClause guardClause, 
-            float input, 
-            string parameterName, 
+        public static float NegativeOrZero(this IGuardClause guardClause,
+            float input,
+            string parameterName,
             string? message = null)
 #else
         public static float NegativeOrZero(this IGuardClause guardClause,
@@ -280,8 +280,8 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
         public static double NegativeOrZero(this IGuardClause guardClause,
-            double input, 
-            string parameterName, 
+            double input,
+            string parameterName,
             string? message = null)
 #else
         public static double NegativeOrZero(this IGuardClause guardClause,
@@ -302,9 +302,9 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        public static TimeSpan NegativeOrZero(this IGuardClause guardClause, 
-            TimeSpan input, 
-            string parameterName, 
+        public static TimeSpan NegativeOrZero(this IGuardClause guardClause,
+            TimeSpan input,
+            string parameterName,
             string? message = null)
 #else
         public static TimeSpan NegativeOrZero(this IGuardClause guardClause,
@@ -326,9 +326,9 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        private static T NegativeOrZero<T>(this IGuardClause guardClause, 
-            T input, 
-            string parameterName, 
+        private static T NegativeOrZero<T>(this IGuardClause guardClause,
+            T input,
+            string parameterName,
             string? message = null) where T : struct, IComparable
 #else
         private static T NegativeOrZero<T>(this IGuardClause guardClause,

--- a/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
@@ -16,9 +16,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not null.</returns>
         /// <exception cref="NotFoundException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static T NotFound<T>(this IGuardClause guardClause, 
-            [NotNull][ValidatedNotNull] string key, 
-            [NotNull][ValidatedNotNull]T input, 
+        public static T NotFound<T>(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull] string key,
+            [NotNull][ValidatedNotNull] T input,
             string parameterName)
 #else
         public static T NotFound<T>(this IGuardClause guardClause,
@@ -49,9 +49,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not null.</returns>
         /// <exception cref="NotFoundException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static T NotFound<TKey, T>(this IGuardClause guardClause, 
-            [NotNull][ValidatedNotNull] TKey key, 
-            [NotNull][ValidatedNotNull]T input, 
+        public static T NotFound<TKey, T>(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull] TKey key,
+            [NotNull][ValidatedNotNull] T input,
             string parameterName) where TKey : struct
 #else
         public static T NotFound<TKey, T>(this IGuardClause guardClause,

--- a/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
-using JetBrainsNoEnumerationAttribute = JetBrains.Annotations.NoEnumerationAttribute;
-using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace Ardalis.GuardClauses
 {
@@ -19,15 +16,15 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not null.</returns>
         /// <exception cref="NotFoundException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static T NotFound<T>([JetBrainsNotNull] this IGuardClause guardClause, 
-            [NotNull, JetBrainsNotNull][ValidatedNotNull] string key, 
-            [NotNull, JetBrainsNotNull][ValidatedNotNull][JetBrainsNoEnumeration] T input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName)
+        public static T NotFound<T>(this IGuardClause guardClause, 
+            [NotNull][ValidatedNotNull] string key, 
+            [NotNull][ValidatedNotNull]T input, 
+            string parameterName)
 #else
-        public static T NotFound<T>([JetBrainsNotNull] this IGuardClause guardClause,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull] string key,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull][JetBrainsNoEnumeration] T input,
-            [JetBrainsNotNull][CallerArgumentExpression("input")] string? parameterName = null)
+        public static T NotFound<T>(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull] string key,
+            [NotNull][ValidatedNotNull] T input,
+            [CallerArgumentExpression("input")] string? parameterName = null)
 #endif
         {
             guardClause.NullOrEmpty(key, nameof(key));
@@ -52,15 +49,15 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not null.</returns>
         /// <exception cref="NotFoundException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static T NotFound<TKey, T>([JetBrainsNotNull] this IGuardClause guardClause, 
-            [NotNull, JetBrainsNotNull][ValidatedNotNull] TKey key, 
-            [NotNull, JetBrainsNotNull][ValidatedNotNull][JetBrainsNoEnumeration] T input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName) where TKey : struct
+        public static T NotFound<TKey, T>(this IGuardClause guardClause, 
+            [NotNull][ValidatedNotNull] TKey key, 
+            [NotNull][ValidatedNotNull]T input, 
+            string parameterName) where TKey : struct
 #else
-        public static T NotFound<TKey, T>([JetBrainsNotNull] this IGuardClause guardClause,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull] TKey key,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull][JetBrainsNoEnumeration] T input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null) where TKey : struct
+        public static T NotFound<TKey, T>(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull] TKey key,
+            [NotNull][ValidatedNotNull]T input,
+            [CallerArgumentExpression("input")] string? parameterName = null) where TKey : struct
 #endif
         {
             guardClause.Null(key, nameof(key));

--- a/src/GuardClauses/GuardAgainstNullExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNullExtensions.cs
@@ -25,7 +25,7 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not null.</returns>
 #if NETSTANDARD || NETFRAMEWORK
         public static T Null<T>(this IGuardClause guardClause,
-            [NotNull][ValidatedNotNull]T input,
+            [NotNull][ValidatedNotNull] T input,
             string parameterName,
             string? message = null)
 #else
@@ -185,9 +185,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not default for that type.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static T Default<T>(this IGuardClause guardClause, 
-            [AllowNull, NotNull]T input, 
-            string parameterName, 
+        public static T Default<T>(this IGuardClause guardClause,
+            [AllowNull, NotNull] T input,
+            string parameterName,
             string? message = null)
 #else
         public static T Default<T>(this IGuardClause guardClause,
@@ -220,7 +220,7 @@ namespace Ardalis.GuardClauses
         /// <exception cref="ArgumentNullException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
         public static T NullOrInvalidInput<T>(this IGuardClause guardClause,
-            T input, 
+            T input,
             string parameterName,
             Func<T, bool> predicate,
             string? message = null)

--- a/src/GuardClauses/GuardAgainstNullExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNullExtensions.cs
@@ -3,9 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
-using JetBrainsNoEnumerationAttribute = JetBrains.Annotations.NoEnumerationAttribute;
-using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace Ardalis.GuardClauses
 {
@@ -27,14 +24,14 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not null.</returns>
 #if NETSTANDARD || NETFRAMEWORK
-        public static T Null<T>([JetBrainsNotNull] this IGuardClause guardClause,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull][JetBrainsNoEnumeration] T input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName,
+        public static T Null<T>(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull]T input,
+            string parameterName,
             string? message = null)
 #else
-        public static T Null<T>([JetBrainsNotNull] this IGuardClause guardClause,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull][JetBrainsNoEnumeration] T input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+        public static T Null<T>(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull]T input,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -62,14 +59,14 @@ namespace Ardalis.GuardClauses
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static string NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName,
+        public static string NullOrEmpty(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull] string? input,
+            string parameterName,
             string? message = null)
 #else
-        public static string NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+        public static string NullOrEmpty(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull] string? input,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -94,14 +91,14 @@ namespace Ardalis.GuardClauses
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static Guid NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull] Guid? input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName,
+        public static Guid NullOrEmpty(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull] Guid? input,
+            string parameterName,
             string? message = null)
 #else
-        public static Guid NullOrEmpty([JetBrainsNotNull] this IGuardClause guardClause,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull] Guid? input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+        public static Guid NullOrEmpty(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull] Guid? input,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -126,14 +123,14 @@ namespace Ardalis.GuardClauses
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static IEnumerable<T> NullOrEmpty<T>([JetBrainsNotNull] this IGuardClause guardClause,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull] IEnumerable<T>? input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName,
+        public static IEnumerable<T> NullOrEmpty<T>(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull] IEnumerable<T>? input,
+            string parameterName,
             string? message = null)
 #else
-        public static IEnumerable<T> NullOrEmpty<T>([JetBrainsNotNull] this IGuardClause guardClause,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull] IEnumerable<T>? input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+        public static IEnumerable<T> NullOrEmpty<T>(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull] IEnumerable<T>? input,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -158,14 +155,14 @@ namespace Ardalis.GuardClauses
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static string NullOrWhiteSpace([JetBrainsNotNull] this IGuardClause guardClause,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName,
+        public static string NullOrWhiteSpace(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull] string? input,
+            string parameterName,
             string? message = null)
 #else
-        public static string NullOrWhiteSpace([JetBrainsNotNull] this IGuardClause guardClause,
-            [NotNull, JetBrainsNotNull][ValidatedNotNull] string? input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+        public static string NullOrWhiteSpace(this IGuardClause guardClause,
+            [NotNull][ValidatedNotNull] string? input,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -188,14 +185,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not default for that type.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static T Default<T>([JetBrainsNotNull] this IGuardClause guardClause, 
-            [AllowNull, NotNull, JetBrainsNotNull][JetBrainsNoEnumeration] T input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+        public static T Default<T>(this IGuardClause guardClause, 
+            [AllowNull, NotNull]T input, 
+            string parameterName, 
             string? message = null)
 #else
-        public static T Default<T>([JetBrainsNotNull] this IGuardClause guardClause,
-            [AllowNull, NotNull, JetBrainsNotNull][JetBrainsNoEnumeration] T input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+        public static T Default<T>(this IGuardClause guardClause,
+            [AllowNull, NotNull]T input,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -222,16 +219,16 @@ namespace Ardalis.GuardClauses
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentNullException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static T NullOrInvalidInput<T>([JetBrainsNotNull] this IGuardClause guardClause, 
-            [JetBrainsNotNull] T input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
-            Func<T, bool> predicate, 
+        public static T NullOrInvalidInput<T>(this IGuardClause guardClause,
+            T input, 
+            string parameterName,
+            Func<T, bool> predicate,
             string? message = null)
 #else
-        public static T NullOrInvalidInput<T>([JetBrainsNotNull] this IGuardClause guardClause, 
-            [JetBrainsNotNull] T input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
-            Func<T, bool> predicate, 
+        public static T NullOrInvalidInput<T>(this IGuardClause guardClause,
+            T input,
+            string parameterName,
+            Func<T, bool> predicate,
             string? message = null)
 #endif
         {

--- a/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
@@ -19,7 +19,7 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="InvalidEnumArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static int EnumOutOfRange<T>(this IGuardClause guardClause, 
+        public static int EnumOutOfRange<T>(this IGuardClause guardClause,
             int input,
             string parameterName,
             string? message = null) where T : struct, Enum
@@ -53,9 +53,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="InvalidEnumArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static T EnumOutOfRange<T>(this IGuardClause guardClause, 
+        public static T EnumOutOfRange<T>(this IGuardClause guardClause,
             T input,
-            string parameterName, 
+            string parameterName,
             string? message = null) where T : struct, Enum
 #else
         public static T EnumOutOfRange<T>(this IGuardClause guardClause,

--- a/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
-using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace Ardalis.GuardClauses
 {
@@ -21,14 +19,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="InvalidEnumArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static int EnumOutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, 
-            int input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+        public static int EnumOutOfRange<T>(this IGuardClause guardClause, 
+            int input,
+            string parameterName,
             string? message = null) where T : struct, Enum
 #else
-        public static int EnumOutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause,
+        public static int EnumOutOfRange<T>(this IGuardClause guardClause,
             int input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null) where T : struct, Enum
 #endif
         {
@@ -55,14 +53,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="InvalidEnumArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static T EnumOutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause, 
-            T input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+        public static T EnumOutOfRange<T>(this IGuardClause guardClause, 
+            T input,
+            string parameterName, 
             string? message = null) where T : struct, Enum
 #else
-        public static T EnumOutOfRange<T>([JetBrainsNotNull] this IGuardClause guardClause,
+        public static T EnumOutOfRange<T>(this IGuardClause guardClause,
             T input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null) where T : struct, Enum
 #endif
         {
@@ -118,14 +116,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static DateTime OutOfSQLDateRange([JetBrainsNotNull] this IGuardClause guardClause,
+        public static DateTime OutOfSQLDateRange(this IGuardClause guardClause,
             DateTime input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName,
+            string parameterName,
             string? message = null)
 #else
-        public static DateTime OutOfSQLDateRange([JetBrainsNotNull] this IGuardClause guardClause,
+        public static DateTime OutOfSQLDateRange(this IGuardClause guardClause,
             DateTime input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -148,7 +146,7 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not out of range.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         public static T OutOfRange<T>(this IGuardClause guardClause, T input,
-            [JetBrainsInvokerParameterName] string parameterName,
+            string parameterName,
             T rangeFrom,
             T rangeTo,
             string? message = null) where T : IComparable, IComparable<T>

--- a/src/GuardClauses/GuardAgainstZeroExtensions.cs
+++ b/src/GuardClauses/GuardAgainstZeroExtensions.cs
@@ -16,9 +16,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static int Zero(this IGuardClause guardClause, 
-            int input, 
-            string parameterName, 
+        public static int Zero(this IGuardClause guardClause,
+            int input,
+            string parameterName,
             string? message = null)
 #else
         public static int Zero(this IGuardClause guardClause,
@@ -40,9 +40,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static long Zero(this IGuardClause guardClause, 
-            long input, 
-            string parameterName, 
+        public static long Zero(this IGuardClause guardClause,
+            long input,
+            string parameterName,
             string? message = null)
 #else
         public static long Zero(this IGuardClause guardClause,
@@ -88,9 +88,9 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static float Zero(this IGuardClause guardClause, 
-            float input, 
-            string parameterName, 
+        public static float Zero(this IGuardClause guardClause,
+            float input,
+            string parameterName,
             string? message = null)
 #else
         public static float Zero(this IGuardClause guardClause,
@@ -135,8 +135,8 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static TimeSpan Zero(this IGuardClause guardClause, 
-            TimeSpan input, 
+        public static TimeSpan Zero(this IGuardClause guardClause,
+            TimeSpan input,
             string parameterName)
 #else
         public static TimeSpan Zero(this IGuardClause guardClause,

--- a/src/GuardClauses/GuardAgainstZeroExtensions.cs
+++ b/src/GuardClauses/GuardAgainstZeroExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using JetBrainsInvokerParameterNameAttribute = JetBrains.Annotations.InvokerParameterNameAttribute;
-using JetBrainsNotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace Ardalis.GuardClauses
 {
@@ -18,14 +16,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static int Zero([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static int Zero(this IGuardClause guardClause, 
             int input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static int Zero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static int Zero(this IGuardClause guardClause,
             int input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -42,14 +40,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static long Zero([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static long Zero(this IGuardClause guardClause, 
             long input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static long Zero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static long Zero(this IGuardClause guardClause,
             long input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -66,14 +64,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static decimal Zero([JetBrainsNotNull] this IGuardClause guardClause, 
-            decimal input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+        public static decimal Zero(this IGuardClause guardClause,
+            decimal input,
+            string parameterName,
             string? message = null)
 #else
-        public static decimal Zero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static decimal Zero(this IGuardClause guardClause,
             decimal input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -90,14 +88,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static float Zero([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static float Zero(this IGuardClause guardClause, 
             float input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+            string parameterName, 
             string? message = null)
 #else
-        public static float Zero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static float Zero(this IGuardClause guardClause,
             float input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -114,14 +112,14 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static double Zero([JetBrainsNotNull] this IGuardClause guardClause, 
-            double input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, 
+        public static double Zero(this IGuardClause guardClause,
+            double input,
+            string parameterName,
             string? message = null)
 #else
-        public static double Zero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static double Zero(this IGuardClause guardClause,
             double input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null,
+            [CallerArgumentExpression("input")] string? parameterName = null,
             string? message = null)
 #endif
         {
@@ -137,13 +135,13 @@ namespace Ardalis.GuardClauses
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
-        public static TimeSpan Zero([JetBrainsNotNull] this IGuardClause guardClause, 
+        public static TimeSpan Zero(this IGuardClause guardClause, 
             TimeSpan input, 
-            [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName)
+            string parameterName)
 #else
-        public static TimeSpan Zero([JetBrainsNotNull] this IGuardClause guardClause,
+        public static TimeSpan Zero(this IGuardClause guardClause,
             TimeSpan input,
-            [JetBrainsNotNull][JetBrainsInvokerParameterName][CallerArgumentExpression("input")] string? parameterName = null)
+            [CallerArgumentExpression("input")] string? parameterName = null)
 #endif
         {
             return Zero<TimeSpan>(guardClause, input, parameterName!);
@@ -158,7 +156,7 @@ namespace Ardalis.GuardClauses
         /// <param name="message">Optional. Custom error message</param>
         /// <returns><paramref name="input" /> if the value is not zero.</returns>
         /// <exception cref="ArgumentException"></exception>
-        private static T Zero<T>([JetBrainsNotNull] this IGuardClause guardClause, T input, [JetBrainsNotNull][JetBrainsInvokerParameterName] string parameterName, string? message = null) where T : struct
+        private static T Zero<T>(this IGuardClause guardClause, T input, string parameterName, string? message = null) where T : struct
         {
             if (EqualityComparer<T>.Default.Equals(input, default(T)))
             {

--- a/src/GuardClauses/GuardClauses.csproj
+++ b/src/GuardClauses/GuardClauses.csproj
@@ -31,7 +31,6 @@
     <DocumentationFile>bin\$(Configuration)\Ardalis.GuardClauses.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/src/GuardClauses/GuardClauses.csproj
+++ b/src/GuardClauses/GuardClauses.csproj
@@ -3,7 +3,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
 </ItemGroup>
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451;net60</TargetFrameworks>
@@ -31,8 +31,8 @@
     <DocumentationFile>bin\$(Configuration)\Ardalis.GuardClauses.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1-*" PrivateAssets="All" />
+    <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />

--- a/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
@@ -3,86 +3,85 @@ using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstDefault
 {
-    public class GuardAgainstDefault
+    [Fact]
+    public void DoesNothingGivenNonDefaultValue()
     {
-        [Fact]
-        public void DoesNothingGivenNonDefaultValue()
-        {
-            Guard.Against.Default("", "string");
-            Guard.Against.Default(1, "int");
-            Guard.Against.Default(Guid.NewGuid(), "guid");
-            Guard.Against.Default(DateTime.Now, "datetime");
-            Guard.Against.Default(new Object(), "object");
-        }
+        Guard.Against.Default("", "string");
+        Guard.Against.Default(1, "int");
+        Guard.Against.Default(Guid.NewGuid(), "guid");
+        Guard.Against.Default(DateTime.Now, "datetime");
+        Guard.Against.Default(new Object(), "object");
+    }
 
-        [Fact]
-        public void ThrowsGivenDefaultValue()
-        {
-            Assert.Throws<ArgumentException>("string", () => Guard.Against.Default(default(string), "string"));
-            Assert.Throws<ArgumentException>("int", () => Guard.Against.Default(default(int), "int"));
-            Assert.Throws<ArgumentException>("guid", () => Guard.Against.Default(default(Guid), "guid"));
-            Assert.Throws<ArgumentException>("datetime", () => Guard.Against.Default(default(DateTime), "datetime"));
-            Assert.Throws<ArgumentException>("object", () => Guard.Against.Default(default(object), "object"));
-        }
+    [Fact]
+    public void ThrowsGivenDefaultValue()
+    {
+        Assert.Throws<ArgumentException>("string", () => Guard.Against.Default(default(string), "string"));
+        Assert.Throws<ArgumentException>("int", () => Guard.Against.Default(default(int), "int"));
+        Assert.Throws<ArgumentException>("guid", () => Guard.Against.Default(default(Guid), "guid"));
+        Assert.Throws<ArgumentException>("datetime", () => Guard.Against.Default(default(DateTime), "datetime"));
+        Assert.Throws<ArgumentException>("object", () => Guard.Against.Default(default(object), "object"));
+    }
 
-        [Theory]
-        [MemberData(nameof(GetNonDefaultTestVectors))]
-        public void ReturnsExpectedValueWhenGivenNonDefaultValue(object input, string name, object expected)
-        {
-            var actual = Guard.Against.Default(input, name);
-            Assert.Equal(expected, actual);
-        }
+    [Theory]
+    [MemberData(nameof(GetNonDefaultTestVectors))]
+    public void ReturnsExpectedValueWhenGivenNonDefaultValue(object input, string name, object expected)
+    {
+        var actual = Guard.Against.Default(input, name);
+        Assert.Equal(expected, actual);
+    }
 
-        [Theory]
-        [InlineData(null, "Parameter [parameterName] is default value for type String (Parameter 'parameterName')")]
-        [InlineData("Please provide correct value", "Please provide correct value (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Default(default(string), "parameterName", customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Parameter [parameterName] is default value for type String (Parameter 'parameterName')")]
+    [InlineData("Please provide correct value", "Please provide correct value (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Default(default(string), "parameterName", customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, "Parameter [xyz] is default value for type String (Parameter 'xyz')")]
-        [InlineData("Please provide correct value", "Please provide correct value (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided(string customMessage, string expectedMessage)
-        {
-            var xyz = default(string);
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Default(xyz, message: customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Parameter [xyz] is default value for type String (Parameter 'xyz')")]
+    [InlineData("Please provide correct value", "Please provide correct value (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided(string customMessage, string expectedMessage)
+    {
+        var xyz = default(string);
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Default(xyz, message: customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Default(default(string), expectedParamName, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Default(default(string), expectedParamName, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
 
-        public static IEnumerable<object[]> GetNonDefaultTestVectors()
-        {
-            yield return new object[] { "", "string", "" };
-            yield return new object[] { 1, "int", 1 };
+    public static IEnumerable<object[]> GetNonDefaultTestVectors()
+    {
+        yield return new object[] { "", "string", "" };
+        yield return new object[] { 1, "int", 1 };
 
-            var guid = Guid.NewGuid();
-            yield return new object[] { guid, "guid", guid };
+        var guid = Guid.NewGuid();
+        yield return new object[] { guid, "guid", guid };
 
-            var now = DateTime.Now;
-            yield return new object[] { now, "now", now };
+        var now = DateTime.Now;
+        yield return new object[] { now, "now", now };
 
-            var obj = new Object();
-            yield return new object[] { obj, "obj", obj };
-        }
+        var obj = new Object();
+        yield return new object[] { obj, "obj", obj };
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstExpression.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstExpression.cs
@@ -12,7 +12,7 @@ namespace GuardClauses.UnitTests
             public string FieldName { get; set; }
         }
 
-        private static IEnumerable<object[]> GetCustomStruct()
+        public static IEnumerable<object[]> GetCustomStruct()
         {
             yield return new object[] {
                 new CustomStruct

--- a/test/GuardClauses.UnitTests/GuardAgainstExpression.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstExpression.cs
@@ -3,76 +3,75 @@ using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstExpression
 {
-    public class GuardAgainstExpression
+    public struct CustomStruct
     {
-        public struct CustomStruct
-        {
-            public string FieldName { get; set; }
-        }
+        public string FieldName { get; set; }
+    }
 
-        public static IEnumerable<object[]> GetCustomStruct()
-        {
-            yield return new object[] {
-                new CustomStruct
-                {
-                    FieldName = "FieldValue"
-                }
-            };
-        }
+    public static IEnumerable<object[]> GetCustomStruct()
+    {
+        yield return new object[] {
+            new CustomStruct
+            {
+                FieldName = "FieldValue"
+            }
+        };
+    }
 
-        [Theory]
-        [InlineData(10)]
-        public void GivenIntegerWhenTheExpressionEvaluatesToTrueDoesNothing(int test)
-        {
-            Guard.Against.AgainstExpression((x) => x == 10, test, "Value is not equal to 10");
-        }
+    [Theory]
+    [InlineData(10)]
+    public void GivenIntegerWhenTheExpressionEvaluatesToTrueDoesNothing(int test)
+    {
+        Guard.Against.AgainstExpression((x) => x == 10, test, "Value is not equal to 10");
+    }
 
-        [Theory]
-        [InlineData(10)]
-        public void GivenIntegerWhenTheExpressionEvaluatesToFalseThrowsException(int test)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.AgainstExpression((x) => x == 5, test, "Value is not equal to 10"));
-        }
+    [Theory]
+    [InlineData(10)]
+    public void GivenIntegerWhenTheExpressionEvaluatesToFalseThrowsException(int test)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.AgainstExpression((x) => x == 5, test, "Value is not equal to 10"));
+    }
 
-        [Theory]
-        [InlineData(1.1)]
-        public void GivenDoubleWhenTheExpressionEvaluatesToTrueDoesNothing(double test)
-        {
-            Guard.Against.AgainstExpression((x) => x == 1.1, test, "Value is not equal to 1.1");
-        }
+    [Theory]
+    [InlineData(1.1)]
+    public void GivenDoubleWhenTheExpressionEvaluatesToTrueDoesNothing(double test)
+    {
+        Guard.Against.AgainstExpression((x) => x == 1.1, test, "Value is not equal to 1.1");
+    }
 
-        [Theory]
-        [InlineData(1.1)]
-        public void GivenDoubleWhenTheExpressionEvaluatesToFalseThrowsException(int test)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.AgainstExpression((x) => x == 5.0, test, "Value is not equal to 1.1"));
-        }
+    [Theory]
+    [InlineData(1.1)]
+    public void GivenDoubleWhenTheExpressionEvaluatesToFalseThrowsException(int test)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.AgainstExpression((x) => x == 5.0, test, "Value is not equal to 1.1"));
+    }
 
-        [Theory]
-        [MemberData(nameof(GetCustomStruct))]
-        public void GivenCustomStructWhenTheExpressionEvaluatesToTrueDoesNothing(CustomStruct test)
-        {
-            Guard.Against.AgainstExpression((x) => x.FieldName == "FieldValue", test, "FieldValue is not matching");
-        }
+    [Theory]
+    [MemberData(nameof(GetCustomStruct))]
+    public void GivenCustomStructWhenTheExpressionEvaluatesToTrueDoesNothing(CustomStruct test)
+    {
+        Guard.Against.AgainstExpression((x) => x.FieldName == "FieldValue", test, "FieldValue is not matching");
+    }
 
-        [Theory]
-        [MemberData(nameof(GetCustomStruct))]
-        public void GivenCustomStructWhenTheExpressionEvaluatesToFalseThrowsException(CustomStruct test)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.AgainstExpression((x) => x.FieldName == "FailThis", test, "FieldValue is not matching"));
-        }
+    [Theory]
+    [MemberData(nameof(GetCustomStruct))]
+    public void GivenCustomStructWhenTheExpressionEvaluatesToFalseThrowsException(CustomStruct test)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.AgainstExpression((x) => x.FieldName == "FailThis", test, "FieldValue is not matching"));
+    }
 
-        [Theory]
-        [InlineData(null, "Value does not fall within the expected range.")]
-        [InlineData("Please provide correct value", "Please provide correct value")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.AgainstExpression(x => x == 1, 2, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Value does not fall within the expected range.")]
+    [InlineData("Please provide correct value", "Please provide correct value")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.AgainstExpression(x => x == 1, 2, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstFooExtension.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstFooExtension.cs
@@ -2,33 +2,32 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstFooExtension
 {
-    public class GuardAgainstFooExtension
+    [Fact]
+    public void ThrowsGivenFoo()
     {
-        [Fact]
-        public void ThrowsGivenFoo()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Foo("foo", "aParameterName"));
-        }
+        Assert.Throws<ArgumentException>(() => Guard.Against.Foo("foo", "aParameterName"));
+    }
 
-        [Fact]
-        public void DoesNothingGivenAnythingElse()
-        {
-            Guard.Against.Foo("anythingElse", "aParameterName");
-            //Guard.Against.Foo(null, "aParameterName");
-        }
+    [Fact]
+    public void DoesNothingGivenAnythingElse()
+    {
+        Guard.Against.Foo("anythingElse", "aParameterName");
+        //Guard.Against.Foo(null, "aParameterName");
+    }
 
-        [Fact]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided()
-        {
-            string? xyz = "foo";
+    [Fact]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided()
+    {
+        string? xyz = "foo";
 
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Foo(xyz));
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Foo(xyz));
 
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Contains($"Should not have been foo! (Parameter '{nameof(xyz)}')", exception.Message);
-        }
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Contains($"Should not have been foo! (Parameter '{nameof(xyz)}')", exception.Message);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
@@ -2,55 +2,54 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstInvalidFormatTests
 {
-    public class GuardAgainstInvalidFormatTests
+    [Theory]
+    [InlineData("12345", @"\d{1,6}")]
+    [InlineData("50FA", @"[0-9a-fA-F]{1,6}")]
+    [InlineData("abfACD", @"[a-fA-F]{1,8}")]
+    [InlineData("DHSTRY", @"[A-Z]+")]
+    [InlineData("3498792", @"\d+")]
+    public void ReturnsExpectedValueGivenCorrectFormat(string input, string regexPattern)
     {
-        [Theory]
-        [InlineData("12345",@"\d{1,6}")]
-        [InlineData("50FA", @"[0-9a-fA-F]{1,6}")]
-        [InlineData("abfACD", @"[a-fA-F]{1,8}")]
-        [InlineData("DHSTRY",@"[A-Z]+")]
-        [InlineData("3498792", @"\d+")]
-        public void ReturnsExpectedValueGivenCorrectFormat(string input,string regexPattern)
-        {
-            var result = Guard.Against.InvalidFormat(input, nameof(input), regexPattern);
-            Assert.Equal(input, result);
-        }
+        var result = Guard.Against.InvalidFormat(input, nameof(input), regexPattern);
+        Assert.Equal(input, result);
+    }
 
-        [Theory]
-        [InlineData("aaa", @"\d{1,6}")]
-        [InlineData("50XA", @"[0-9a-fA-F]{1,6}")]
-        [InlineData("2GudhUtG", @"[a-fA-F]+")]
-        [InlineData("sDHSTRY", @"[A-Z]+")]
-        [InlineData("3F498792", @"\d+")]
-        [InlineData("", @"\d+")]
-        public void ThrowsGivenGivenIncorrectFormat(string input, string regexPattern)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat(input, nameof(input), regexPattern));
-        }
+    [Theory]
+    [InlineData("aaa", @"\d{1,6}")]
+    [InlineData("50XA", @"[0-9a-fA-F]{1,6}")]
+    [InlineData("2GudhUtG", @"[a-fA-F]+")]
+    [InlineData("sDHSTRY", @"[A-Z]+")]
+    [InlineData("3F498792", @"\d+")]
+    [InlineData("", @"\d+")]
+    public void ThrowsGivenGivenIncorrectFormat(string input, string regexPattern)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat(input, nameof(input), regexPattern));
+    }
 
-        [Theory]
-        [InlineData(null, "Input parameterName was not in required format (Parameter 'parameterName')")]
-        [InlineData("Please provide value in a correct format", "Please provide value in a correct format (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat("aaa", "parameterName", "^b", customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Input parameterName was not in required format (Parameter 'parameterName')")]
+    [InlineData("Please provide value in a correct format", "Please provide value in a correct format (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat("aaa", "parameterName", "^b", customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat("aaa", expectedParamName, "^b", customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat("aaa", expectedParamName, "^b", customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
@@ -3,241 +3,240 @@ using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstNegative
 {
-    public class GuardAgainstNegative
+    [Fact]
+    public void DoesNothingGivenZeroValue()
     {
-        [Fact]
-        public void DoesNothingGivenZeroValue()
+        Guard.Against.Negative(0, "intZero");
+        Guard.Against.Negative(0L, "longZero");
+        Guard.Against.Negative(0.0M, "decimalZero");
+        Guard.Against.Negative(0.0f, "floatZero");
+        Guard.Against.Negative(0.0, "doubleZero");
+        Guard.Against.Negative(TimeSpan.Zero, "timespanZero");
+    }
+
+    [Fact]
+    public void DoesNothingGivenPositiveValue()
+    {
+        Guard.Against.Negative(1, "intZero");
+        Guard.Against.Negative(1L, "longZero");
+        Guard.Against.Negative(1.0M, "decimalZero");
+        Guard.Against.Negative(1.0f, "floatZero");
+        Guard.Against.Negative(1.0, "doubleZero");
+        Guard.Against.Negative(TimeSpan.FromSeconds(1), "timespanZero");
+    }
+
+    [Fact]
+    public void ThrowsGivenNegativeIntValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1, "negative"));
+    }
+
+    [Fact]
+    public void ThrowsGivenNegativeLongValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1L, "negative"));
+    }
+
+    [Fact]
+    public void ThrowsGivenNegativeDecimalValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0M, "negative"));
+    }
+
+    [Fact]
+    public void ThrowsGivenNegativeFloatValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0f, "negative"));
+    }
+
+    [Fact]
+    public void ThrowsGivenNegativeDoubleValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0, "negative"));
+    }
+
+    [Fact]
+    public void ThrowsGivenNegativeTimeSpanValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Negative(TimeSpan.FromSeconds(-1), "negative"));
+    }
+
+    [Fact]
+    public void ReturnsExpectedValueGivenNonNegativeIntValue()
+    {
+        Assert.Equal(0, Guard.Against.Negative(0, "intZero"));
+        Assert.Equal(1, Guard.Against.Negative(1, "intOne"));
+    }
+
+    [Fact]
+    public void ReturnsExpectedValueGivenNonNegativeLongValue()
+    {
+        Assert.Equal(0L, Guard.Against.Negative(0L, "longZero"));
+        Assert.Equal(1L, Guard.Against.Negative(1L, "longOne"));
+    }
+
+    [Fact]
+    public void ReturnsExpectedValueGivenNonNegativeDecimalValue()
+    {
+        Assert.Equal(0.0M, Guard.Against.Negative(0.0M, "decimalZero"));
+        Assert.Equal(1.0M, Guard.Against.Negative(1.0M, "decimalOne"));
+    }
+
+    [Fact]
+    public void ReturnsExpectedValueGivenNonNegativeFloatValue()
+    {
+        Assert.Equal(0.0f, Guard.Against.Negative(0.0f, "floatZero"));
+        Assert.Equal(1.0f, Guard.Against.Negative(1.0f, "floatOne"));
+    }
+
+    [Fact]
+    public void ReturnsExpectedValueGivenNonNegativeDoubleValue()
+    {
+        Assert.Equal(0.0, Guard.Against.Negative(0.0, "doubleZero"));
+        Assert.Equal(1.0, Guard.Against.Negative(1.0, "doubleOne"));
+    }
+
+    [Fact]
+    public void ReturnsExpectedValueGivenNonNegativeTimeSpanValue()
+    {
+        Assert.Equal(TimeSpan.Zero, Guard.Against.Negative(TimeSpan.Zero, "timespanZero"));
+        Assert.Equal(TimeSpan.FromSeconds(1), Guard.Against.Negative(TimeSpan.FromSeconds(1), "timespanOne"));
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
+    [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenIntValue(string customMessage, string expectedMessage)
+    {
+        var xyz = -1;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
+    [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenLongValue(string customMessage, string expectedMessage)
+    {
+        var xyz = -1L;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
+    [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDecimalValue(string customMessage, string expectedMessage)
+    {
+        var xyz = -1.0M;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
+    [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenFloatValue(string customMessage, string expectedMessage)
+    {
+        var xyz = -1.0f;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
+    [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDoubleValue(string customMessage, string expectedMessage)
+    {
+        var xyz = -1.0;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
+    [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenTimeSpanValue(string customMessage, string expectedMessage)
+    {
+        var xyz = TimeSpan.FromSeconds(-1);
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input parameterName cannot be negative. (Parameter 'parameterName')")]
+    [InlineData("Must be positive", "Must be positive (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var clausesToEvaluate = new List<Action>
         {
-            Guard.Against.Negative(0, "intZero");
-            Guard.Against.Negative(0L, "longZero");
-            Guard.Against.Negative(0.0M, "decimalZero");
-            Guard.Against.Negative(0.0f, "floatZero");
-            Guard.Against.Negative(0.0, "doubleZero");
-            Guard.Against.Negative(TimeSpan.Zero, "timespanZero");
-        }
+            () => Guard.Against.Negative(-1, "parameterName", customMessage),
+            () => Guard.Against.Negative(-1L, "parameterName", customMessage),
+            () => Guard.Against.Negative(-1.0M, "parameterName", customMessage),
+            () => Guard.Against.Negative(-1.0f, "parameterName", customMessage),
+            () => Guard.Against.Negative(-1.0, "parameterName", customMessage),
+            () => Guard.Against.Negative(TimeSpan.FromSeconds(-1), "parameterName", customMessage)
+        };
 
-        [Fact]
-        public void DoesNothingGivenPositiveValue()
+        foreach (var clauseToEvaluate in clausesToEvaluate)
         {
-            Guard.Against.Negative(1, "intZero");
-            Guard.Against.Negative(1L, "longZero");
-            Guard.Against.Negative(1.0M, "decimalZero");
-            Guard.Against.Negative(1.0f, "floatZero");
-            Guard.Against.Negative(1.0, "doubleZero");
-            Guard.Against.Negative(TimeSpan.FromSeconds(1), "timespanZero");
-        }
-
-        [Fact]
-        public void ThrowsGivenNegativeIntValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1, "negative"));
-        }
-
-        [Fact]
-        public void ThrowsGivenNegativeLongValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1L, "negative"));
-        }
-
-        [Fact]
-        public void ThrowsGivenNegativeDecimalValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0M, "negative"));
-        }
-
-        [Fact]
-        public void ThrowsGivenNegativeFloatValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0f, "negative"));
-        }
-
-        [Fact]
-        public void ThrowsGivenNegativeDoubleValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0, "negative"));
-        }
-
-        [Fact]
-        public void ThrowsGivenNegativeTimeSpanValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Negative(TimeSpan.FromSeconds(-1), "negative"));
-        }
-
-        [Fact]
-        public void ReturnsExpectedValueGivenNonNegativeIntValue()
-        {
-            Assert.Equal(0, Guard.Against.Negative(0, "intZero"));
-            Assert.Equal(1, Guard.Against.Negative(1, "intOne"));
-        }
-
-        [Fact]
-        public void ReturnsExpectedValueGivenNonNegativeLongValue()
-        {
-            Assert.Equal(0L, Guard.Against.Negative(0L, "longZero"));
-            Assert.Equal(1L, Guard.Against.Negative(1L, "longOne"));
-        }
-
-        [Fact]
-        public void ReturnsExpectedValueGivenNonNegativeDecimalValue()
-        {
-            Assert.Equal(0.0M, Guard.Against.Negative(0.0M, "decimalZero"));
-            Assert.Equal(1.0M, Guard.Against.Negative(1.0M, "decimalOne"));
-        }
-
-        [Fact]
-        public void ReturnsExpectedValueGivenNonNegativeFloatValue()
-        {
-            Assert.Equal(0.0f, Guard.Against.Negative(0.0f, "floatZero"));
-            Assert.Equal(1.0f, Guard.Against.Negative(1.0f, "floatOne"));
-        }
-
-        [Fact]
-        public void ReturnsExpectedValueGivenNonNegativeDoubleValue()
-        {
-            Assert.Equal(0.0, Guard.Against.Negative(0.0, "doubleZero"));
-            Assert.Equal(1.0, Guard.Against.Negative(1.0, "doubleOne"));
-        }
-
-        [Fact]
-        public void ReturnsExpectedValueGivenNonNegativeTimeSpanValue()
-        {
-            Assert.Equal(TimeSpan.Zero, Guard.Against.Negative(TimeSpan.Zero, "timespanZero"));
-            Assert.Equal(TimeSpan.FromSeconds(1), Guard.Against.Negative(TimeSpan.FromSeconds(1), "timespanOne"));
-        }
-
-        [Theory]
-        [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
-        [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenIntValue(string customMessage, string expectedMessage)
-        {
-            var xyz = -1;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
-
+            var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
         }
+    }
 
-        [Theory]
-        [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
-        [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenLongValue(string customMessage, string expectedMessage)
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var clausesToEvaluate = new List<Action>
         {
-            var xyz = -1L;
+            () => Guard.Against.Negative(-1, expectedParamName, customMessage),
+            () => Guard.Against.Negative(-1L, expectedParamName, customMessage),
+            () => Guard.Against.Negative(-1.0M, expectedParamName, customMessage),
+            () => Guard.Against.Negative(-1.0f, expectedParamName, customMessage),
+            () => Guard.Against.Negative(-1.0, expectedParamName, customMessage),
+            () => Guard.Against.Negative(TimeSpan.FromSeconds(-1), expectedParamName, customMessage)
+        };
 
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
-
+        foreach (var clauseToEvaluate in clausesToEvaluate)
+        {
+            var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
             Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
-        [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDecimalValue(string customMessage, string expectedMessage)
-        {
-            var xyz = -1.0M;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
-
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
-        [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenFloatValue(string customMessage, string expectedMessage)
-        {
-            var xyz = -1.0f;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
-
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
-        [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDoubleValue(string customMessage, string expectedMessage)
-        {
-            var xyz = -1.0;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
-
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, "Required input xyz cannot be negative. (Parameter 'xyz')")]
-        [InlineData("Must be positive", "Must be positive (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenTimeSpanValue(string customMessage, string expectedMessage)
-        {
-            var xyz = TimeSpan.FromSeconds(-1);
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(xyz, message: customMessage));
-
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, "Required input parameterName cannot be negative. (Parameter 'parameterName')")]
-        [InlineData("Must be positive", "Must be positive (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var clausesToEvaluate = new List<Action>
-            {
-                () => Guard.Against.Negative(-1, "parameterName", customMessage),
-                () => Guard.Against.Negative(-1L, "parameterName", customMessage),
-                () => Guard.Against.Negative(-1.0M, "parameterName", customMessage),
-                () => Guard.Against.Negative(-1.0f, "parameterName", customMessage),
-                () => Guard.Against.Negative(-1.0, "parameterName", customMessage),
-                () => Guard.Against.Negative(TimeSpan.FromSeconds(-1), "parameterName", customMessage)
-            };
-
-            foreach (var clauseToEvaluate in clausesToEvaluate)
-            {
-                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
-                Assert.NotNull(exception);
-                Assert.NotNull(exception.Message);
-                Assert.Equal(expectedMessage, exception.Message);
-            }
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var clausesToEvaluate = new List<Action>
-            {
-                () => Guard.Against.Negative(-1, expectedParamName, customMessage),
-                () => Guard.Against.Negative(-1L, expectedParamName, customMessage),
-                () => Guard.Against.Negative(-1.0M, expectedParamName, customMessage),
-                () => Guard.Against.Negative(-1.0f, expectedParamName, customMessage),
-                () => Guard.Against.Negative(-1.0, expectedParamName, customMessage),
-                () => Guard.Against.Negative(TimeSpan.FromSeconds(-1), expectedParamName, customMessage)
-            };
-
-            foreach (var clauseToEvaluate in clausesToEvaluate)
-            {
-                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
-                Assert.NotNull(exception);
-                Assert.Equal(expectedParamName, exception.ParamName);
-            }
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
@@ -3,250 +3,249 @@ using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstNegativeOrZero
 {
-    public class GuardAgainstNegativeOrZero
+    [Fact]
+    public void DoesNothingGivenPositiveValue()
     {
-        [Fact]
-        public void DoesNothingGivenPositiveValue()
+        Guard.Against.NegativeOrZero(1, "intPositive");
+        Guard.Against.NegativeOrZero(1L, "longPositive");
+        Guard.Against.NegativeOrZero(1.0M, "decimalPositive");
+        Guard.Against.NegativeOrZero(1.0f, "floatPositive");
+        Guard.Against.NegativeOrZero(1.0, "doublePositive");
+        Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(1), "timespanPositive");
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroIntValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0, "intZero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroLongValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0L, "longZero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroDecimalValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0M, "decimalZero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroFloatValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0f, "floatZero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroDoubleValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0.0, "doubleZero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroTimeSpanValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(TimeSpan.Zero, "timespanZero"));
+    }
+
+
+    [Fact]
+    public void ThrowsGivenNegativeIntValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1, "intNegative"));
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-42, "intNegative"));
+    }
+
+    [Fact]
+    public void ThrowsGivenNegativeLongValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1L, "longNegative"));
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-456L, "longNegative"));
+    }
+
+    [Fact]
+    public void ThrowsGivenNegativeDecimalValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1M, "decimalNegative"));
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-567M, "decimalNegative"));
+    }
+
+    [Fact]
+    public void ThrowsGivenNegativeFloatValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1f, "floatNegative"));
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-4567f, "floatNegative"));
+    }
+
+    [Fact]
+    public void ThrowsGivenNegativeDoubleValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1.0, "doubleNegative"));
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-456.453, "doubleNegative"));
+    }
+
+    [Fact]
+    public void ThrowsGivenNegativeTimeSpanValue()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(-1), "timespanNegative"));
+        Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(-456), "timespanNegative"));
+    }
+
+    [Fact]
+    public void ReturnsExpectedValueWhenGivenPositiveValue()
+    {
+        Assert.Equal(1, Guard.Against.NegativeOrZero(1, "intPositive"));
+        Assert.Equal(1L, Guard.Against.NegativeOrZero(1L, "longPositive"));
+        Assert.Equal(1.0M, Guard.Against.NegativeOrZero(1.0M, "decimalPositive"));
+        Assert.Equal(1.0f, Guard.Against.NegativeOrZero(1.0f, "floatPositive"));
+        Assert.Equal(1.0, Guard.Against.NegativeOrZero(1.0, "doublePositive"));
+        Assert.Equal(TimeSpan.FromSeconds(1), Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(1), "timespanPositive"));
+    }
+
+    [Theory]
+    [InlineData(-1, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+    [InlineData(-1, "Must be positive", "Must be positive (Parameter 'xyz')")]
+    [InlineData(0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+    [InlineData(0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenIntValue(int xyz, string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(-1L, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+    [InlineData(-1L, "Must be positive", "Must be positive (Parameter 'xyz')")]
+    [InlineData(0L, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+    [InlineData(0L, "Must be positive", "Must be positive (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenLongValue(long xyz, string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(-1.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+    [InlineData(-1.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+    [InlineData(0.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+    [InlineData(0.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDecimalValue(decimal xyz, string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(-1.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+    [InlineData(-1.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+    [InlineData(0.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+    [InlineData(0.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenFloatValue(float xyz, string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(-1.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+    [InlineData(-1.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+    [InlineData(0.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+    [InlineData(0.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDoubleValue(double xyz, string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(-1.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+    [InlineData(-1.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+    [InlineData(0.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
+    [InlineData(0.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenTimeSpanValue(double change, string customMessage, string expectedMessage)
+    {
+        var xyz = TimeSpan.FromSeconds(change);
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(-1, null, "Required input parameterName cannot be zero or negative. (Parameter 'parameterName')")]
+    [InlineData(-1, "Must be positive", "Must be positive (Parameter 'parameterName')")]
+    [InlineData(0, null, "Required input parameterName cannot be zero or negative. (Parameter 'parameterName')")]
+    [InlineData(0, "Must be positive", "Must be positive (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(int input, string customMessage, string expectedMessage)
+    {
+        var clausesToEvaluate = new List<Action>
         {
-            Guard.Against.NegativeOrZero(1, "intPositive");
-            Guard.Against.NegativeOrZero(1L, "longPositive");
-            Guard.Against.NegativeOrZero(1.0M, "decimalPositive");
-            Guard.Against.NegativeOrZero(1.0f, "floatPositive");
-            Guard.Against.NegativeOrZero(1.0, "doublePositive");
-            Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(1), "timespanPositive");
-        }
+            () => Guard.Against.NegativeOrZero(input, "parameterName", customMessage),
+            () => Guard.Against.NegativeOrZero((long)input, "parameterName", customMessage),
+            () => Guard.Against.NegativeOrZero((decimal)input, "parameterName", customMessage),
+            () => Guard.Against.NegativeOrZero((float)input, "parameterName", customMessage),
+            () => Guard.Against.NegativeOrZero((double)input, "parameterName", customMessage),
+            () => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(input), "parameterName", customMessage)
+        };
 
-        [Fact]
-        public void ThrowsGivenZeroIntValue()
+        foreach (var clauseToEvaluate in clausesToEvaluate)
         {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0, "intZero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroLongValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0L, "longZero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroDecimalValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0M, "decimalZero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroFloatValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0f, "floatZero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroDoubleValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0.0, "doubleZero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroTimeSpanValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(TimeSpan.Zero, "timespanZero"));
-        }
-
-
-        [Fact]
-        public void ThrowsGivenNegativeIntValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1, "intNegative"));
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-42, "intNegative"));
-        }
-
-        [Fact]
-        public void ThrowsGivenNegativeLongValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1L, "longNegative"));
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-456L, "longNegative"));
-        }
-
-        [Fact]
-        public void ThrowsGivenNegativeDecimalValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1M, "decimalNegative"));
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-567M, "decimalNegative"));
-        }
-
-        [Fact]
-        public void ThrowsGivenNegativeFloatValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1f, "floatNegative"));
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-4567f, "floatNegative"));
-        }
-
-        [Fact]
-        public void ThrowsGivenNegativeDoubleValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1.0, "doubleNegative"));
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-456.453, "doubleNegative"));
-        }
-
-        [Fact]
-        public void ThrowsGivenNegativeTimeSpanValue()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(-1), "timespanNegative"));
-            Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(-456), "timespanNegative"));
-        }
-
-        [Fact]
-        public void ReturnsExpectedValueWhenGivenPositiveValue()
-        {
-            Assert.Equal(1, Guard.Against.NegativeOrZero(1, "intPositive"));
-            Assert.Equal(1L, Guard.Against.NegativeOrZero(1L, "longPositive"));
-            Assert.Equal(1.0M, Guard.Against.NegativeOrZero(1.0M, "decimalPositive"));
-            Assert.Equal(1.0f, Guard.Against.NegativeOrZero(1.0f, "floatPositive"));
-            Assert.Equal(1.0, Guard.Against.NegativeOrZero(1.0, "doublePositive"));
-            Assert.Equal(TimeSpan.FromSeconds(1), Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(1), "timespanPositive"));
-        }
-
-        [Theory]
-        [InlineData(-1, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
-        [InlineData(-1, "Must be positive", "Must be positive (Parameter 'xyz')")]
-        [InlineData(0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
-        [InlineData(0, "Must be positive", "Must be positive (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenIntValue(int xyz, string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
-
+            var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
         }
+    }
 
-        [Theory]
-        [InlineData(-1L, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
-        [InlineData(-1L, "Must be positive", "Must be positive (Parameter 'xyz')")]
-        [InlineData(0L, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
-        [InlineData(0L, "Must be positive", "Must be positive (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenLongValue(long xyz, string customMessage, string expectedMessage)
+    [Theory]
+    [InlineData(-1, null, null)]
+    [InlineData(-1, null, "Please provide correct value")]
+    [InlineData(-1, "SomeParameter", null)]
+    [InlineData(-1, "SomeOtherParameter", "Value must be correct")]
+    [InlineData(0, null, null)]
+    [InlineData(0, null, "Please provide correct value")]
+    [InlineData(0, "SomeParameter", null)]
+    [InlineData(0, "SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(int input, string expectedParamName, string customMessage)
+    {
+        var clausesToEvaluate = new List<Action>
         {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
+            () => Guard.Against.NegativeOrZero(input, expectedParamName, customMessage),
+            () => Guard.Against.NegativeOrZero((long)input, expectedParamName, customMessage),
+            () => Guard.Against.NegativeOrZero((decimal)input, expectedParamName, customMessage),
+            () => Guard.Against.NegativeOrZero((float)input, expectedParamName, customMessage),
+            () => Guard.Against.NegativeOrZero((double)input, expectedParamName, customMessage),
+            () => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(input), expectedParamName, customMessage)
+        };
 
+        foreach (var clauseToEvaluate in clausesToEvaluate)
+        {
+            var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
             Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(-1.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
-        [InlineData(-1.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
-        [InlineData(0.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
-        [InlineData(0.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDecimalValue(decimal xyz, string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
-
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(-1.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
-        [InlineData(-1.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
-        [InlineData(0.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
-        [InlineData(0.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenFloatValue(float xyz, string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
-
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(-1.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
-        [InlineData(-1.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
-        [InlineData(0.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
-        [InlineData(0.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDoubleValue(double xyz, string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
-
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(-1.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
-        [InlineData(-1.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
-        [InlineData(0.0, null, "Required input xyz cannot be zero or negative. (Parameter 'xyz')")]
-        [InlineData(0.0, "Must be positive", "Must be positive (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenTimeSpanValue(double change, string customMessage, string expectedMessage)
-        {
-            var xyz = TimeSpan.FromSeconds(change);
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(xyz, message: customMessage));
-
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(-1, null, "Required input parameterName cannot be zero or negative. (Parameter 'parameterName')")]
-        [InlineData(-1, "Must be positive", "Must be positive (Parameter 'parameterName')")]
-        [InlineData(0, null, "Required input parameterName cannot be zero or negative. (Parameter 'parameterName')")]
-        [InlineData(0, "Must be positive", "Must be positive (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(int input, string customMessage, string expectedMessage)
-        {
-            var clausesToEvaluate = new List<Action>
-            {
-                () => Guard.Against.NegativeOrZero(input, "parameterName", customMessage),
-                () => Guard.Against.NegativeOrZero((long)input, "parameterName", customMessage),
-                () => Guard.Against.NegativeOrZero((decimal)input, "parameterName", customMessage),
-                () => Guard.Against.NegativeOrZero((float)input, "parameterName", customMessage),
-                () => Guard.Against.NegativeOrZero((double)input, "parameterName", customMessage),
-                () => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(input), "parameterName", customMessage)
-            };
-
-            foreach (var clauseToEvaluate in clausesToEvaluate)
-            {
-                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
-                Assert.NotNull(exception);
-                Assert.NotNull(exception.Message);
-                Assert.Equal(expectedMessage, exception.Message);
-            }
-        }
-
-        [Theory]
-        [InlineData(-1, null, null)]
-        [InlineData(-1, null, "Please provide correct value")]
-        [InlineData(-1, "SomeParameter", null)]
-        [InlineData(-1, "SomeOtherParameter", "Value must be correct")]
-        [InlineData(0, null, null)]
-        [InlineData(0, null, "Please provide correct value")]
-        [InlineData(0, "SomeParameter", null)]
-        [InlineData(0, "SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(int input, string expectedParamName, string customMessage)
-        {
-            var clausesToEvaluate = new List<Action>
-            {
-                () => Guard.Against.NegativeOrZero(input, expectedParamName, customMessage),
-                () => Guard.Against.NegativeOrZero((long)input, expectedParamName, customMessage),
-                () => Guard.Against.NegativeOrZero((decimal)input, expectedParamName, customMessage),
-                () => Guard.Against.NegativeOrZero((float)input, expectedParamName, customMessage),
-                () => Guard.Against.NegativeOrZero((double)input, expectedParamName, customMessage),
-                () => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(input), expectedParamName, customMessage)
-            };
-
-            foreach (var clauseToEvaluate in clausesToEvaluate)
-            {
-                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
-                Assert.NotNull(exception);
-                Assert.Equal(expectedParamName, exception.ParamName);
-            }
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNotFound.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNotFound.cs
@@ -2,66 +2,65 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstNotFound
 {
-    public class GuardAgainstNotFound
+    [Fact]
+    public void DoesNothingGivenNonNullValue()
     {
-        [Fact]
-        public void DoesNothingGivenNonNullValue()
-        {
-            Guard.Against.NotFound("mykey", "", "string");
-            Guard.Against.NotFound(1, 1, "int");
-            Guard.Against.NotFound(1, Guid.Empty, "guid");
-            Guard.Against.NotFound(Guid.Empty, DateTime.Now, "datetime");
-            Guard.Against.NotFound(1, new Object(), "object");
-        }
+        Guard.Against.NotFound("mykey", "", "string");
+        Guard.Against.NotFound(1, 1, "int");
+        Guard.Against.NotFound(1, Guid.Empty, "guid");
+        Guard.Against.NotFound(Guid.Empty, DateTime.Now, "datetime");
+        Guard.Against.NotFound(1, new Object(), "object");
+    }
 
-        [Fact]
-        public void ThrowsGivenNullValue()
-        {
-            object obj = null!;
-            Assert.Throws<NotFoundException>(() => Guard.Against.NotFound(1, obj, "null"));
-        }
+    [Fact]
+    public void ThrowsGivenNullValue()
+    {
+        object obj = null!;
+        Assert.Throws<NotFoundException>(() => Guard.Against.NotFound(1, obj, "null"));
+    }
 
-        [Fact]
-        public void ReturnsExpectedValueWhenGivenNonNullValue()
-        {
-            Assert.Equal("", Guard.Against.NotFound("mykey", "", "string"));
-            Assert.Equal(1, Guard.Against.NotFound(1, 1, "int"));
+    [Fact]
+    public void ReturnsExpectedValueWhenGivenNonNullValue()
+    {
+        Assert.Equal("", Guard.Against.NotFound("mykey", "", "string"));
+        Assert.Equal(1, Guard.Against.NotFound(1, 1, "int"));
 
-            var guid = Guid.Empty;
-            Assert.Equal(guid, Guard.Against.NotFound(1, guid, "guid"));
+        var guid = Guid.Empty;
+        Assert.Equal(guid, Guard.Against.NotFound(1, guid, "guid"));
 
-            var now = DateTime.Now;
-            Assert.Equal(now, Guard.Against.NotFound(1, now, "datetime"));
+        var now = DateTime.Now;
+        Assert.Equal(now, Guard.Against.NotFound(1, now, "datetime"));
 
-            var obj = new Object();
-            Assert.Equal(obj, Guard.Against.NotFound(1, obj, "object"));
-        }
+        var obj = new Object();
+        Assert.Equal(obj, Guard.Against.NotFound(1, obj, "object"));
+    }
 
-        [Fact]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenStringValue()
-        {
-            string? xyz = null;
-            var key = "mykey";
+    [Fact]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenStringValue()
+    {
+        string? xyz = null;
+        var key = "mykey";
 
-            var exception = Assert.Throws<NotFoundException>(() => Guard.Against.NotFound(key, xyz));
+        var exception = Assert.Throws<NotFoundException>(() => Guard.Against.NotFound(key, xyz));
 
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Contains($"Queried object {nameof(xyz)} was not found, Key: {key}", exception.Message);
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Contains($"Queried object {nameof(xyz)} was not found, Key: {key}", exception.Message);
 
-            //Assert.Equal("", Guard.Against.NotFound("mykey", "", "string"));
-            //Assert.Equal(1, Guard.Against.NotFound(1, 1, "int"));
+        //Assert.Equal("", Guard.Against.NotFound("mykey", "", "string"));
+        //Assert.Equal(1, Guard.Against.NotFound(1, 1, "int"));
 
-            //var guid = Guid.Empty;
-            //Assert.Equal(guid, Guard.Against.NotFound(1, guid, "guid"));
+        //var guid = Guid.Empty;
+        //Assert.Equal(guid, Guard.Against.NotFound(1, guid, "guid"));
 
-            //var now = DateTime.Now;
-            //Assert.Equal(now, Guard.Against.NotFound(1, now, "datetime"));
+        //var now = DateTime.Now;
+        //Assert.Equal(now, Guard.Against.NotFound(1, now, "datetime"));
 
-            //var obj = new Object();
-            //Assert.Equal(obj, Guard.Against.NotFound(1, obj, "object"));
-        }
+        //var obj = new Object();
+        //Assert.Equal(obj, Guard.Against.NotFound(1, obj, "object"));
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNull.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNull.cs
@@ -2,78 +2,77 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstNull
 {
-    public class GuardAgainstNull
+    [Fact]
+    public void DoesNothingGivenNonNullValue()
     {
-        [Fact]
-        public void DoesNothingGivenNonNullValue()
-        {
-            Guard.Against.Null("", "string");
-            Guard.Against.Null(1, "int");
-            Guard.Against.Null(Guid.Empty, "guid");
-            Guard.Against.Null(DateTime.Now, "datetime");
-            Guard.Against.Null(new Object(), "object");
-        }
+        Guard.Against.Null("", "string");
+        Guard.Against.Null(1, "int");
+        Guard.Against.Null(Guid.Empty, "guid");
+        Guard.Against.Null(DateTime.Now, "datetime");
+        Guard.Against.Null(new Object(), "object");
+    }
 
-        [Fact]
-        public void ThrowsGivenNullValue()
-        {
-            object obj = null!;
-            Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(obj, "null"));
-        }
+    [Fact]
+    public void ThrowsGivenNullValue()
+    {
+        object obj = null!;
+        Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(obj, "null"));
+    }
 
-        [Fact]
-        public void ReturnsExpectedValueWhenGivenNonNullValue()
-        {
-            Assert.Equal("", Guard.Against.Null("", "string"));
-            Assert.Equal(1, Guard.Against.Null(1, "int"));
+    [Fact]
+    public void ReturnsExpectedValueWhenGivenNonNullValue()
+    {
+        Assert.Equal("", Guard.Against.Null("", "string"));
+        Assert.Equal(1, Guard.Against.Null(1, "int"));
 
-            var guid = Guid.Empty;
-            Assert.Equal(guid, Guard.Against.Null(guid, "guid"));
+        var guid = Guid.Empty;
+        Assert.Equal(guid, Guard.Against.Null(guid, "guid"));
 
-            var now = DateTime.Now;
-            Assert.Equal(now, Guard.Against.Null(now, "datetime"));
+        var now = DateTime.Now;
+        Assert.Equal(now, Guard.Against.Null(now, "datetime"));
 
-            var obj = new Object();
-            Assert.Equal(obj, Guard.Against.Null(obj, "object"));
-        }
+        var obj = new Object();
+        Assert.Equal(obj, Guard.Against.Null(obj, "object"));
+    }
 
-        [Theory]
-        [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
-        [InlineData("Please provide correct value", "Please provide correct value (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            string? nullString = null;
-            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(nullString, "parameterName", customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
+    [InlineData("Please provide correct value", "Please provide correct value (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        string? nullString = null;
+        var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(nullString, "parameterName", customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Fact]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided()
-        {
-            string? xyz = null;
+    [Fact]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided()
+    {
+        string? xyz = null;
 
-            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(xyz));
+        var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(xyz));
 
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Contains($"Value cannot be null. (Parameter '{nameof(xyz)}')", exception.Message);
-        }
-      
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            string? nullString = null;
-            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(nullString, expectedParamName, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Contains($"Value cannot be null. (Parameter '{nameof(xyz)}')", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        string? nullString = null;
+        var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(nullString, expectedParamName, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
@@ -4,217 +4,216 @@ using System.Linq;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstNullOrEmpty
 {
-    public class GuardAgainstNullOrEmpty
+    [Fact]
+    public void DoesNothingGivenNonEmptyStringValue()
     {
-        [Fact]
-        public void DoesNothingGivenNonEmptyStringValue()
+        Guard.Against.NullOrEmpty("a", "string");
+        Guard.Against.NullOrEmpty("1", "aNumericString");
+    }
+
+    [Fact]
+    public void DoesNothingGivenNonEmptyGuidValue()
+    {
+        Guard.Against.NullOrEmpty(Guid.NewGuid(), "guid");
+    }
+
+    [Fact]
+    public void DoesNothingGivenNonEmptyEnumerable()
+    {
+        Guard.Against.NullOrEmpty(new[] { "foo", "bar" }, "stringArray");
+        Guard.Against.NullOrEmpty(new[] { 1, 2 }, "intArray");
+    }
+
+    [Fact]
+    public void ThrowsGivenNullString()
+    {
+        string? nullString = null;
+        Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullString, "nullString"));
+    }
+
+    [Fact]
+    public void ThrowsGivenEmptyString()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty("", "emptyString"));
+    }
+
+    [Fact]
+    public void ThrowsGivenNullGuid()
+    {
+        Guid? nullGuid = null;
+        Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullGuid, "nullGuid"));
+    }
+
+    [Fact]
+    public void ThrowsGivenEmptyGuid()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Guid.Empty, "emptyGuid"));
+    }
+
+    [Fact]
+    public void ThrowsGivenEmptyEnumerable()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Enumerable.Empty<string>(), "emptyStringEnumerable"));
+    }
+
+    [Fact]
+    public void ReturnsExpectedValueWhenGivenValidValue()
+    {
+        Assert.Equal("a", Guard.Against.NullOrEmpty("a", "string"));
+        Assert.Equal("1", Guard.Against.NullOrEmpty("1", "aNumericString"));
+
+        var collection1 = new[] { "foo", "bar" };
+        Assert.Equal(collection1, Guard.Against.NullOrEmpty(collection1, "stringArray"));
+
+        var collection2 = new[] { 1, 2 };
+        Assert.Equal(collection2, Guard.Against.NullOrEmpty(collection2, "intArray"));
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz was empty. (Parameter 'xyz')")]
+    [InlineData("Value is empty", "Value is empty (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenStringValue(string customMessage, string expectedMessage)
+    {
+        string xyz = string.Empty;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Contains(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz was empty. (Parameter 'xyz')")]
+    [InlineData("Value is empty", "Value is empty (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenGuidValue(string customMessage, string expectedMessage)
+    {
+        Guid xyz = Guid.Empty;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Contains(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz was empty. (Parameter 'xyz')")]
+    [InlineData("Value is empty", "Value is empty (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenIEnumerableValue(string customMessage, string expectedMessage)
+    {
+        IEnumerable<string> xyz = Enumerable.Empty<string>();
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Contains(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input parameterName was empty. (Parameter 'parameterName')")]
+    [InlineData("Value is empty", "Value is empty (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenInputIsEmpty(string customMessage, string expectedMessage)
+    {
+        string emptyString = string.Empty;
+        Guid emptyGuid = Guid.Empty;
+        IEnumerable<string> emptyEnumerable = Enumerable.Empty<string>();
+
+        var clausesToEvaluate = new List<Action>
         {
-            Guard.Against.NullOrEmpty("a", "string");
-            Guard.Against.NullOrEmpty("1", "aNumericString");
-        }
+            () => Guard.Against.NullOrEmpty(emptyString, "parameterName", customMessage),
+            () => Guard.Against.NullOrEmpty(emptyGuid, "parameterName", customMessage),
+            () => Guard.Against.NullOrEmpty(emptyEnumerable, "parameterName", customMessage)
+        };
 
-        [Fact]
-        public void DoesNothingGivenNonEmptyGuidValue()
+        foreach (var clauseToEvaluate in clausesToEvaluate)
         {
-            Guard.Against.NullOrEmpty(Guid.NewGuid(), "guid");
-        }
-
-        [Fact]
-        public void DoesNothingGivenNonEmptyEnumerable()
-        {
-            Guard.Against.NullOrEmpty(new[] { "foo", "bar" }, "stringArray");
-            Guard.Against.NullOrEmpty(new[] { 1, 2 }, "intArray");
-        }
-
-        [Fact]
-        public void ThrowsGivenNullString()
-        {
-            string? nullString = null;
-            Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullString, "nullString"));
-        }
-
-        [Fact]
-        public void ThrowsGivenEmptyString()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty("", "emptyString"));
-        }
-
-        [Fact]
-        public void ThrowsGivenNullGuid()
-        {
-            Guid? nullGuid = null;
-            Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullGuid, "nullGuid"));
-        }
-
-        [Fact]
-        public void ThrowsGivenEmptyGuid()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Guid.Empty, "emptyGuid"));
-        }
-
-        [Fact]
-        public void ThrowsGivenEmptyEnumerable()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Enumerable.Empty<string>(), "emptyStringEnumerable"));
-        }
-
-        [Fact]
-        public void ReturnsExpectedValueWhenGivenValidValue()
-        {
-            Assert.Equal("a", Guard.Against.NullOrEmpty("a", "string"));
-            Assert.Equal("1", Guard.Against.NullOrEmpty("1", "aNumericString"));
-
-            var collection1 = new[] { "foo", "bar" };
-            Assert.Equal(collection1, Guard.Against.NullOrEmpty(collection1, "stringArray"));
-
-            var collection2 = new[] { 1, 2 };
-            Assert.Equal(collection2, Guard.Against.NullOrEmpty(collection2, "intArray"));
-        }
-
-        [Theory]
-        [InlineData(null, "Required input xyz was empty. (Parameter 'xyz')")]
-        [InlineData("Value is empty", "Value is empty (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenStringValue(string customMessage, string expectedMessage)
-        {
-            string xyz = string.Empty;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(xyz, message: customMessage));
-
+            var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Contains(expectedMessage, exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
+    }
 
-        [Theory]
-        [InlineData(null, "Required input xyz was empty. (Parameter 'xyz')")]
-        [InlineData("Value is empty", "Value is empty (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenGuidValue(string customMessage, string expectedMessage)
+    [Theory]
+    [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
+    [InlineData("Value must be correct", "Value must be correct (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenInputIsNull(string customMessage, string expectedMessage)
+    {
+        string? nullString = null;
+        Guid? nullGuid = null;
+        IEnumerable<string>? nullEnumerable = null;
+
+        var clausesToEvaluate = new List<Action>
         {
-            Guid xyz = Guid.Empty;
+            () => Guard.Against.NullOrEmpty(nullString, "parameterName", customMessage),
+            () => Guard.Against.NullOrEmpty(nullGuid, "parameterName", customMessage),
+            () => Guard.Against.NullOrEmpty(nullEnumerable, "parameterName", customMessage)
+        };
 
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(xyz, message: customMessage));
-
+        foreach (var clauseToEvaluate in clausesToEvaluate)
+        {
+            var exception = Assert.Throws<ArgumentNullException>(clauseToEvaluate);
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
-            Assert.Contains(expectedMessage, exception.Message);
+            Assert.Equal(expectedMessage, exception.Message);
         }
+    }
 
-        [Theory]
-        [InlineData(null, "Required input xyz was empty. (Parameter 'xyz')")]
-        [InlineData("Value is empty", "Value is empty (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenIEnumerableValue(string customMessage, string expectedMessage)
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedWhenInputIsEmpty(string expectedParamName, string customMessage)
+    {
+        string emptyString = string.Empty;
+        Guid emptyGuid = Guid.Empty;
+        IEnumerable<string> emptyEnumerable = Enumerable.Empty<string>();
+
+        var clausesToEvaluate = new List<Action>
         {
-            IEnumerable<string> xyz = Enumerable.Empty<string>();
+            () => Guard.Against.NullOrEmpty(emptyString, expectedParamName, customMessage),
+            () => Guard.Against.NullOrEmpty(emptyGuid, expectedParamName, customMessage),
+            () => Guard.Against.NullOrEmpty(emptyEnumerable, expectedParamName, customMessage)
+        };
 
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(xyz, message: customMessage));
-
+        foreach (var clauseToEvaluate in clausesToEvaluate)
+        {
+            var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
             Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Contains(expectedMessage, exception.Message);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
+    }
 
-        [Theory]
-        [InlineData(null, "Required input parameterName was empty. (Parameter 'parameterName')")]
-        [InlineData("Value is empty", "Value is empty (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenInputIsEmpty(string customMessage, string expectedMessage)
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedWhenInputIsNull(string expectedParamName, string customMessage)
+    {
+        string? nullString = null;
+        Guid? nullGuid = null;
+        IEnumerable<string>? nullEnumerable = null;
+
+        var clausesToEvaluate = new List<Action>
         {
-            string emptyString = string.Empty;
-            Guid emptyGuid = Guid.Empty;
-            IEnumerable<string> emptyEnumerable = Enumerable.Empty<string>();
+            () => Guard.Against.NullOrEmpty(nullString, expectedParamName, customMessage),
+            () => Guard.Against.NullOrEmpty(nullGuid, expectedParamName, customMessage),
+            () => Guard.Against.NullOrEmpty(nullEnumerable, expectedParamName, customMessage)
+        };
 
-            var clausesToEvaluate = new List<Action>
-            {
-                () => Guard.Against.NullOrEmpty(emptyString, "parameterName", customMessage),
-                () => Guard.Against.NullOrEmpty(emptyGuid, "parameterName", customMessage),
-                () => Guard.Against.NullOrEmpty(emptyEnumerable, "parameterName", customMessage)
-            };
-
-            foreach (var clauseToEvaluate in clausesToEvaluate)
-            {
-                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
-                Assert.NotNull(exception);
-                Assert.NotNull(exception.Message);
-                Assert.Equal(expectedMessage, exception.Message);
-            }
-        }
-
-        [Theory]
-        [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
-        [InlineData("Value must be correct", "Value must be correct (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenInputIsNull(string customMessage, string expectedMessage)
+        foreach (var clauseToEvaluate in clausesToEvaluate)
         {
-            string? nullString = null;
-            Guid? nullGuid = null;
-            IEnumerable<string>? nullEnumerable = null;
-
-            var clausesToEvaluate = new List<Action>
-            {
-                () => Guard.Against.NullOrEmpty(nullString, "parameterName", customMessage),
-                () => Guard.Against.NullOrEmpty(nullGuid, "parameterName", customMessage),
-                () => Guard.Against.NullOrEmpty(nullEnumerable, "parameterName", customMessage)
-            };
-
-            foreach (var clauseToEvaluate in clausesToEvaluate)
-            {
-                var exception = Assert.Throws<ArgumentNullException>(clauseToEvaluate);
-                Assert.NotNull(exception);
-                Assert.NotNull(exception.Message);
-                Assert.Equal(expectedMessage, exception.Message);
-            }
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedWhenInputIsEmpty(string expectedParamName, string customMessage)
-        {
-            string emptyString = string.Empty;
-            Guid emptyGuid = Guid.Empty;
-            IEnumerable<string> emptyEnumerable = Enumerable.Empty<string>();
-
-            var clausesToEvaluate = new List<Action>
-            {
-                () => Guard.Against.NullOrEmpty(emptyString, expectedParamName, customMessage),
-                () => Guard.Against.NullOrEmpty(emptyGuid, expectedParamName, customMessage),
-                () => Guard.Against.NullOrEmpty(emptyEnumerable, expectedParamName, customMessage)
-            };
-
-            foreach (var clauseToEvaluate in clausesToEvaluate)
-            {
-                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
-                Assert.NotNull(exception);
-                Assert.Equal(expectedParamName, exception.ParamName);
-            }
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedWhenInputIsNull(string expectedParamName, string customMessage)
-        {
-            string? nullString = null;
-            Guid? nullGuid = null;
-            IEnumerable<string>? nullEnumerable = null;
-
-            var clausesToEvaluate = new List<Action>
-            {
-                () => Guard.Against.NullOrEmpty(nullString, expectedParamName, customMessage),
-                () => Guard.Against.NullOrEmpty(nullGuid, expectedParamName, customMessage),
-                () => Guard.Against.NullOrEmpty(nullEnumerable, expectedParamName, customMessage)
-            };
-
-            foreach (var clauseToEvaluate in clausesToEvaluate)
-            {
-                var exception = Assert.Throws<ArgumentNullException>(clauseToEvaluate);
-                Assert.NotNull(exception);
-                Assert.Equal(expectedParamName, exception.ParamName);
-            }
+            var exception = Assert.Throws<ArgumentNullException>(clauseToEvaluate);
+            Assert.NotNull(exception);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrInvalidInput.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrInvalidInput.cs
@@ -4,89 +4,88 @@ using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstNullOrInvalidInput
 {
-    public class GuardAgainstNullOrInvalidInput
+    [Theory]
+    [ClassData(typeof(ArgumentNullExceptionClassData))]
+    public void ThrowsArgumentNullExceptionWhenInputIsNull(string input, Func<string, bool> func)
     {
-        [Theory]
-        [ClassData(typeof(ArgumentNullExceptionClassData))]
-        public void ThrowsArgumentNullExceptionWhenInputIsNull(string input, Func<string, bool> func)
-        {
-            Assert.Throws<ArgumentNullException>("string", 
-                () => Guard.Against.NullOrInvalidInput(input, "string", func));
-        }
+        Assert.Throws<ArgumentNullException>("string",
+            () => Guard.Against.NullOrInvalidInput(input, "string", func));
+    }
 
-        [Theory]
-        [ClassData(typeof(ArgumentExceptionClassData))]
-        public void ThrowsArgumentExceptionWhenInputIsInvalid(string input, Func<string, bool> func)
-        {
-            Assert.Throws<ArgumentException>("string",
-                () => Guard.Against.NullOrInvalidInput(input, "string", func));
-        }
+    [Theory]
+    [ClassData(typeof(ArgumentExceptionClassData))]
+    public void ThrowsArgumentExceptionWhenInputIsInvalid(string input, Func<string, bool> func)
+    {
+        Assert.Throws<ArgumentException>("string",
+            () => Guard.Against.NullOrInvalidInput(input, "string", func));
+    }
 
-        [Theory]
-        [ClassData(typeof(ValidClassData))]
-        public void ReturnsExceptedValueWhenGivenValidInput(int input, Func<int, bool> func)
-        {
-            var result = Guard.Against.NullOrInvalidInput(input, nameof(input), func);
-            Assert.Equal(input, result);
-        }
-        
-        [Theory]
-        [InlineData(null, "Input parameterName did not satisfy the options (Parameter 'parameterName')", typeof(ArgumentException), 10)]
-        [InlineData("Evaluation failed", "Evaluation failed (Parameter 'parameterName')", typeof(ArgumentException), 10)]
-        [InlineData(null, "Value cannot be null. (Parameter 'parameterName')", typeof(ArgumentNullException))]
-        [InlineData("Please provide correct value", "Please provide correct value (Parameter 'parameterName')", typeof(ArgumentNullException))]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage, Type exceptionType, int? input = null)
-        {
-            var exception = Assert.Throws(exceptionType,
-                () => Guard.Against.NullOrInvalidInput(input, "parameterName", x => x > 20, customMessage));
-            
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [ClassData(typeof(ValidClassData))]
+    public void ReturnsExceptedValueWhenGivenValidInput(int input, Func<int, bool> func)
+    {
+        var result = Guard.Against.NullOrInvalidInput(input, nameof(input), func);
+        Assert.Equal(input, result);
+    }
 
-        [Theory]
-        [InlineData(null, null, typeof(ArgumentException), 10)]
-        [InlineData(null, "Please provide correct value", typeof(ArgumentException), 10)]
-        [InlineData("SomeParameter", null, typeof(ArgumentNullException))]
-        [InlineData("SomeOtherParameter", "Value must be correct", typeof(ArgumentNullException))]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage, Type exceptionType, int? input = null)
-        {
-            var exception = Assert.Throws(exceptionType,
-                () => Guard.Against.NullOrInvalidInput(input, expectedParamName, x => x > 20, customMessage));
-            
-            Assert.IsAssignableFrom<ArgumentException>(exception);
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, (exception as ArgumentException)!.ParamName);
-        }
+    [Theory]
+    [InlineData(null, "Input parameterName did not satisfy the options (Parameter 'parameterName')", typeof(ArgumentException), 10)]
+    [InlineData("Evaluation failed", "Evaluation failed (Parameter 'parameterName')", typeof(ArgumentException), 10)]
+    [InlineData(null, "Value cannot be null. (Parameter 'parameterName')", typeof(ArgumentNullException))]
+    [InlineData("Please provide correct value", "Please provide correct value (Parameter 'parameterName')", typeof(ArgumentNullException))]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage, Type exceptionType, int? input = null)
+    {
+        var exception = Assert.Throws(exceptionType,
+            () => Guard.Against.NullOrInvalidInput(input, "parameterName", x => x > 20, customMessage));
 
-        public class ValidClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { 20, (Func<int, bool>)(x => x > 10) };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        public class ArgumentNullExceptionClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { null, (Func<string, bool>)(x => x.Length > 10) };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
+    [Theory]
+    [InlineData(null, null, typeof(ArgumentException), 10)]
+    [InlineData(null, "Please provide correct value", typeof(ArgumentException), 10)]
+    [InlineData("SomeParameter", null, typeof(ArgumentNullException))]
+    [InlineData("SomeOtherParameter", "Value must be correct", typeof(ArgumentNullException))]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage, Type exceptionType, int? input = null)
+    {
+        var exception = Assert.Throws(exceptionType,
+            () => Guard.Against.NullOrInvalidInput(input, expectedParamName, x => x > 20, customMessage));
 
-        public class ArgumentExceptionClassData : IEnumerable<object[]>
+        Assert.IsAssignableFrom<ArgumentException>(exception);
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, (exception as ArgumentException)!.ParamName);
+    }
+
+    public class ValidClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { "TestData", (Func<string, bool>)(x => x.Length > 10) };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            yield return new object[] { 20, (Func<int, bool>)(x => x > 10) };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public class ArgumentNullExceptionClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { null, (Func<string, bool>)(x => x.Length > 10) };
+        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public class ArgumentExceptionClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { "TestData", (Func<string, bool>)(x => x.Length > 10) };
+        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -2,112 +2,111 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstNullOrWhiteSpace
 {
-    public class GuardAgainstNullOrWhiteSpace
+    [Theory]
+    [InlineData("a")]
+    [InlineData("1")]
+    [InlineData("some text")]
+    [InlineData(" leading whitespace")]
+    [InlineData("trailing whitespace ")]
+    public void DoesNothingGivenNonEmptyStringValue(string nonEmptyString)
     {
-        [Theory]
-        [InlineData("a")]
-        [InlineData("1")]
-        [InlineData("some text")]
-        [InlineData(" leading whitespace")]
-        [InlineData("trailing whitespace ")]
-        public void DoesNothingGivenNonEmptyStringValue(string nonEmptyString)
-        {
-            Guard.Against.NullOrWhiteSpace(nonEmptyString, "string");
-            Guard.Against.NullOrWhiteSpace(nonEmptyString, "aNumericString");
-        }
+        Guard.Against.NullOrWhiteSpace(nonEmptyString, "string");
+        Guard.Against.NullOrWhiteSpace(nonEmptyString, "aNumericString");
+    }
 
-        [Fact]
-        public void ThrowsGivenNullValue()
-        {
-            Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(null, "null"));
-        }
+    [Fact]
+    public void ThrowsGivenNullValue()
+    {
+        Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(null, "null"));
+    }
 
-        [Fact]
-        public void ThrowsGivenEmptyString()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace("", "emptystring"));
-        }
+    [Fact]
+    public void ThrowsGivenEmptyString()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace("", "emptystring"));
+    }
 
-        [Theory]
-        [InlineData(" ")]
-        [InlineData("   ")]
-        public void ThrowsGivenWhiteSpaceString(string whiteSpaceString)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring"));
-        }
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    public void ThrowsGivenWhiteSpaceString(string whiteSpaceString)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring"));
+    }
 
-        [Theory]
-        [InlineData("a", "a")]
-        [InlineData("1", "1")]
-        [InlineData("some text", "some text")]
-        [InlineData(" leading whitespace", " leading whitespace")]
-        [InlineData("trailing whitespace ", "trailing whitespace ")]
-        public void ReturnsExpectedValueGivenNonEmptyStringValue(string nonEmptyString, string expected)
-        {
-            Assert.Equal(expected, Guard.Against.NullOrWhiteSpace(nonEmptyString, "string"));
-            Assert.Equal(expected, Guard.Against.NullOrWhiteSpace(nonEmptyString, "aNumericString"));
-        }
+    [Theory]
+    [InlineData("a", "a")]
+    [InlineData("1", "1")]
+    [InlineData("some text", "some text")]
+    [InlineData(" leading whitespace", " leading whitespace")]
+    [InlineData("trailing whitespace ", "trailing whitespace ")]
+    public void ReturnsExpectedValueGivenNonEmptyStringValue(string nonEmptyString, string expected)
+    {
+        Assert.Equal(expected, Guard.Against.NullOrWhiteSpace(nonEmptyString, "string"));
+        Assert.Equal(expected, Guard.Against.NullOrWhiteSpace(nonEmptyString, "aNumericString"));
+    }
 
-        [Theory]
-        [InlineData(null, "Required input parameterName was empty. (Parameter 'parameterName')")]
-        [InlineData("Value is empty", "Value is empty (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenInputIsWhiteSpace(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(" ", "parameterName", customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Required input parameterName was empty. (Parameter 'parameterName')")]
+    [InlineData("Value is empty", "Value is empty (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenInputIsWhiteSpace(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(" ", "parameterName", customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
-        [InlineData("Value is null", "Value is null (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenInputIsNull(string customMessage, string expectedMessage)
-        {
-            string? nullString = null;
-            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(nullString, "parameterName", customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
+    [InlineData("Value is null", "Value is null (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenInputIsNull(string customMessage, string expectedMessage)
+    {
+        string? nullString = null;
+        var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(nullString, "parameterName", customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, "Value cannot be null. (Parameter 'xyz')")]
-        [InlineData("Value is null", "Value is null (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided(string customMessage, string expectedMessage)
-        {
-            string? xyz = null;
-            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(xyz, message: customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Value cannot be null. (Parameter 'xyz')")]
+    [InlineData("Value is null", "Value is null (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided(string customMessage, string expectedMessage)
+    {
+        string? xyz = null;
+        var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(xyz, message: customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedWhenInputIsWhiteSpace(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(" ", expectedParamName, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedWhenInputIsWhiteSpace(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(" ", expectedParamName, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedWhenInputIsNull(string expectedParamName, string customMessage)
-        {
-            string? nullString = null;
-            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(nullString, expectedParamName, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedWhenInputIsNull(string expectedParamName, string customMessage)
+    {
+        string? nullString = null;
+        var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrWhiteSpace(nullString, expectedParamName, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
@@ -2,82 +2,81 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForDateTime
 {
-    public class GuardAgainstOutOfRangeForDateTime
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(0, 3)]
+    [InlineData(-1, 1)]
+    [InlineData(-1, 0)]
+    public void DoesNothingGivenInRangeValue(int rangeFromOffset, int rangeToOffset)
     {
-        [Theory]
-        [InlineData(0, 0)]
-        [InlineData(0, 3)]
-        [InlineData(-1, 1)]
-        [InlineData(-1, 0)]
-        public void DoesNothingGivenInRangeValue(int rangeFromOffset, int rangeToOffset)
-        {
-            DateTime input = DateTime.Now;
-            DateTime rangeFrom = input.AddSeconds(rangeFromOffset);
-            DateTime rangeTo = input.AddSeconds(rangeToOffset);
-            Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
-        }
+        DateTime input = DateTime.Now;
+        DateTime rangeFrom = input.AddSeconds(rangeFromOffset);
+        DateTime rangeTo = input.AddSeconds(rangeToOffset);
+        Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
+    }
 
-        [Theory]
-        [InlineData(1, 3)]
-        [InlineData(-4, -3)]
-        public void ThrowsGivenOutOfRangeValue(int rangeFromOffset, int rangeToOffset)
-        {
-            DateTime input = DateTime.Now;
-            DateTime rangeFrom = input.AddSeconds(rangeFromOffset);
-            DateTime rangeTo = input.AddSeconds(rangeToOffset);
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(1, 3)]
+    [InlineData(-4, -3)]
+    public void ThrowsGivenOutOfRangeValue(int rangeFromOffset, int rangeToOffset)
+    {
+        DateTime input = DateTime.Now;
+        DateTime rangeFrom = input.AddSeconds(rangeFromOffset);
+        DateTime rangeTo = input.AddSeconds(rangeToOffset);
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(3, 1)]
-        [InlineData(3, -1)]
-        public void ThrowsGivenInvalidArgumentValue(int rangeFromOffset, int rangeToOffset)
-        {
-            DateTime input = DateTime.Now;
-            DateTime rangeFrom = input.AddSeconds(rangeFromOffset);
-            DateTime rangeTo = input.AddSeconds(rangeToOffset);
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(DateTime.Now, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(3, 1)]
+    [InlineData(3, -1)]
+    public void ThrowsGivenInvalidArgumentValue(int rangeFromOffset, int rangeToOffset)
+    {
+        DateTime input = DateTime.Now;
+        DateTime rangeFrom = input.AddSeconds(rangeFromOffset);
+        DateTime rangeTo = input.AddSeconds(rangeToOffset);
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(DateTime.Now, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(0, 0)]
-        [InlineData(0, 3)]
-        [InlineData(-1, 1)]
-        [InlineData(-1, 0)]
-        public void ReturnsExpectedValueGivenInRangeValue(int rangeFromOffset, int rangeToOffset)
-        {
-            DateTime input = DateTime.Now;
-            DateTime expected = input;
-            DateTime rangeFrom = input.AddSeconds(rangeFromOffset);
-            DateTime rangeTo = input.AddSeconds(rangeToOffset);
-            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(0, 3)]
+    [InlineData(-1, 1)]
+    [InlineData(-1, 0)]
+    public void ReturnsExpectedValueGivenInRangeValue(int rangeFromOffset, int rangeToOffset)
+    {
+        DateTime input = DateTime.Now;
+        DateTime expected = input;
+        DateTime rangeFrom = input.AddSeconds(rangeFromOffset);
+        DateTime rangeTo = input.AddSeconds(rangeToOffset);
+        Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("DateTime range", "DateTime range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(DateTime.Today.AddDays(-1), "parameterName",
-                DateTime.Today, DateTime.Today.AddDays(1), customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
+    [InlineData("DateTime range", "DateTime range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(DateTime.Today.AddDays(-1), "parameterName",
+            DateTime.Today, DateTime.Today.AddDays(1), customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(DateTime.Today.AddDays(-1), expectedParamName,
-                DateTime.Today, DateTime.Today.AddDays(1), customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(DateTime.Today.AddDays(-1), expectedParamName,
+            DateTime.Today, DateTime.Today.AddDays(1), customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
@@ -2,69 +2,68 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForDecimal
 {
-    public class GuardAgainstOutOfRangeForDecimal
+    [Theory]
+    [InlineData(1.0, 1.0, 1.0)]
+    [InlineData(1.0, 1.0, 3.0)]
+    [InlineData(2.0, 1.0, 3.0)]
+    [InlineData(3.0, 1.0, 3.0)]
+    public void DoesNothingGivenInRangeValue(decimal input, decimal rangeFrom, decimal rangeTo)
     {
-        [Theory]
-        [InlineData(1.0, 1.0, 1.0)]
-        [InlineData(1.0, 1.0, 3.0)]
-        [InlineData(2.0, 1.0, 3.0)]
-        [InlineData(3.0, 1.0, 3.0)]
-        public void DoesNothingGivenInRangeValue(decimal input, decimal rangeFrom, decimal rangeTo)
-        {
-            Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
-        }
+        Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
+    }
 
-        [Theory]
-        [InlineData(-1.0, 1.0, 3.0)]
-        [InlineData(0.0, 1.0, 3.0)]
-        [InlineData(4.0, 1.0, 3.0)]
-        public void ThrowsGivenOutOfRangeValue(decimal input, decimal rangeFrom, decimal rangeTo)
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(-1.0, 1.0, 3.0)]
+    [InlineData(0.0, 1.0, 3.0)]
+    [InlineData(4.0, 1.0, 3.0)]
+    public void ThrowsGivenOutOfRangeValue(decimal input, decimal rangeFrom, decimal rangeTo)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(-1.0, 3.0, 1.0)]
-        [InlineData(0.0, 3.0, 1.0)]
-        [InlineData(4.0, 3.0, 1.0)]
-        public void ThrowsGivenInvalidArgumentValue(decimal input, decimal rangeFrom, decimal rangeTo)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(-1.0, 3.0, 1.0)]
+    [InlineData(0.0, 3.0, 1.0)]
+    [InlineData(4.0, 3.0, 1.0)]
+    public void ThrowsGivenInvalidArgumentValue(decimal input, decimal rangeFrom, decimal rangeTo)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(1.0, 0.0, 1.0, 1.0)]
-        [InlineData(1.0, 0.0, 3.0, 1.0)]
-        [InlineData(2.0, 1.0, 3.0, 2.0)]
-        [InlineData(3.0, 3.0, 3.0, 3.0)]
-        public void ReturnsExpectedValueGivenInRangeValue(decimal input, decimal rangeFrom, decimal rangeTo, decimal expected)
-        {
-            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(1.0, 0.0, 1.0, 1.0)]
+    [InlineData(1.0, 0.0, 3.0, 1.0)]
+    [InlineData(2.0, 1.0, 3.0, 2.0)]
+    [InlineData(3.0, 3.0, 3.0, 3.0)]
+    public void ReturnsExpectedValueGivenInRangeValue(decimal input, decimal rangeFrom, decimal rangeTo, decimal expected)
+    {
+        Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Decimal range", "Decimal range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0, "parameterName", 0.0, 1.0, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
+    [InlineData("Decimal range", "Decimal range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0, "parameterName", 0.0, 1.0, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0, expectedParamName, 0.0, 1.0, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0, expectedParamName, 0.0, 1.0, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
@@ -2,69 +2,68 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForDouble
 {
-    public class GuardAgainstOutOfRangeForDouble
+    [Theory]
+    [InlineData(1.0, 1.0, 1.0)]
+    [InlineData(1.0, 1.0, 3.0)]
+    [InlineData(2.0, 1.0, 3.0)]
+    [InlineData(3.0, 1.0, 3.0)]
+    public void DoesNothingGivenInRangeValue(double input, double rangeFrom, double rangeTo)
     {
-        [Theory]
-        [InlineData(1.0, 1.0, 1.0)]
-        [InlineData(1.0, 1.0, 3.0)]
-        [InlineData(2.0, 1.0, 3.0)]
-        [InlineData(3.0, 1.0, 3.0)]
-        public void DoesNothingGivenInRangeValue(double input, double rangeFrom, double rangeTo)
-        {
-            Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
-        }
+        Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
+    }
 
-        [Theory]
-        [InlineData(-1.0, 1.0, 3.0)]
-        [InlineData(0.0, 1.0, 3.0)]
-        [InlineData(4.0, 1.0, 3.0)]
-        public void ThrowsGivenOutOfRangeValue(double input, double rangeFrom, double rangeTo)
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(-1.0, 1.0, 3.0)]
+    [InlineData(0.0, 1.0, 3.0)]
+    [InlineData(4.0, 1.0, 3.0)]
+    public void ThrowsGivenOutOfRangeValue(double input, double rangeFrom, double rangeTo)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(-1.0, 3.0, 1.0)]
-        [InlineData(0.0, 3.0, 1.0)]
-        [InlineData(4.0, 3.0, 1.0)]
-        public void ThrowsGivenInvalidArgumentValue(double input, double rangeFrom, double rangeTo)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(-1.0, 3.0, 1.0)]
+    [InlineData(0.0, 3.0, 1.0)]
+    [InlineData(4.0, 3.0, 1.0)]
+    public void ThrowsGivenInvalidArgumentValue(double input, double rangeFrom, double rangeTo)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(1.0, 0.0, 1.0, 1.0)]
-        [InlineData(1.0, 0.0, 3.0, 1.0)]
-        [InlineData(2.0, 1.0, 3.0, 2.0)]
-        [InlineData(3.0, 3.0, 3.0, 3.0)]
-        public void ReturnsExpectedValueGivenInRangeValue(double input, double rangeFrom, double rangeTo, double expected)
-        {
-            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(1.0, 0.0, 1.0, 1.0)]
+    [InlineData(1.0, 0.0, 3.0, 1.0)]
+    [InlineData(2.0, 1.0, 3.0, 2.0)]
+    [InlineData(3.0, 3.0, 3.0, 3.0)]
+    public void ReturnsExpectedValueGivenInRangeValue(double input, double rangeFrom, double rangeTo, double expected)
+    {
+        Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Double range", "Double range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0d, "parameterName", 0.0d, 1.0d, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
+    [InlineData("Double range", "Double range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0d, "parameterName", 0.0d, 1.0d, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0d, expectedParamName, 0.0d, 1.0d, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0d, expectedParamName, 0.0d, 1.0d, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
@@ -2,155 +2,154 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForEnum
 {
-    public class GuardAgainstOutOfRangeForEnum
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    public void DoesNothingGivenInRangeValue(int enumValue)
     {
-        [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(3)]
-        [InlineData(4)]
-        [InlineData(5)]
-        public void DoesNothingGivenInRangeValue(int enumValue)
-        {
-            Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue));
-        }
-
-
-        [Theory]
-        [InlineData(-1)]
-        [InlineData(6)]
-        [InlineData(10)]
-        public void ThrowsGivenOutOfRangeValue(int enumValue)
-        {
-            var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue)));
-            Assert.Equal(nameof(enumValue), exception.ParamName);
-        }
-
-        [Theory]
-        [InlineData(TestEnum.Budgie)]
-        [InlineData(TestEnum.Cat)]
-        [InlineData(TestEnum.Dog)]
-        [InlineData(TestEnum.Fish)]
-        [InlineData(TestEnum.Frog)]
-        [InlineData(TestEnum.Penguin)]
-        public void DoesNothingGivenInRangeEnum(TestEnum enumValue)
-        {
-            Guard.Against.EnumOutOfRange(enumValue, nameof(enumValue));
-        }
-
-
-        [Theory]
-        [InlineData((TestEnum)(-1))]
-        [InlineData((TestEnum)6)]
-        [InlineData((TestEnum)10)]
-        public void ThrowsGivenOutOfRangeEnum(TestEnum enumValue)
-        {
-            var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.EnumOutOfRange(enumValue, nameof(enumValue)));
-            Assert.Equal(nameof(enumValue), exception.ParamName);
-        }
-
-        [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(3)]
-        [InlineData(4)]
-        [InlineData(5)]
-        public void ReturnsExpectedValueGivenInRangeValue(int enumValue)
-        {
-            var expected = enumValue;
-            Assert.Equal(expected, Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue)));
-        }
-
-        [Theory]
-        [InlineData(TestEnum.Budgie)]
-        [InlineData(TestEnum.Cat)]
-        [InlineData(TestEnum.Dog)]
-        [InlineData(TestEnum.Fish)]
-        [InlineData(TestEnum.Frog)]
-        [InlineData(TestEnum.Penguin)]
-        public void ReturnsExpectedValueGivenInRangeEnum(TestEnum enumValue)
-        {
-            var expected = enumValue;
-            Assert.Equal(expected, Guard.Against.EnumOutOfRange(enumValue, nameof(enumValue)));
-        }
-
-        [Theory]
-        [InlineData(null, "The value of argument 'parameterName' (99) is invalid for Enum type 'TestEnum'. (Parameter 'parameterName')")]
-        [InlineData("Invalid enum value", "Invalid enum value")]
-        public void ErrorMessageMatchesExpectedWhenInputIsEnum(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<InvalidEnumArgumentException>(
-                () => Guard.Against.EnumOutOfRange((TestEnum)99, "parameterName", customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, "The value of argument 'xyz' (99) is invalid for Enum type 'TestEnum'. (Parameter 'xyz')")]
-        [InlineData("Invalid enum value", "Invalid enum value")]
-        public void ErrorMessageMatchesExpectedWhenInputIsEnumAndParamNameNotExplicitlyProvided(string customMessage, string expectedMessage)
-        {
-            var xyz = (TestEnum)99;
-            var exception = Assert.Throws<InvalidEnumArgumentException>(
-                () => Guard.Against.EnumOutOfRange(xyz, message: customMessage));
-
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData(null, "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedWhenInputIsEnum(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<InvalidEnumArgumentException>(
-                () => Guard.Against.EnumOutOfRange((TestEnum)99, expectedParamName, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        [Theory]
-        [InlineData(null, "The value of argument 'parameterName' (99) is invalid for Enum type 'TestEnum'. (Parameter 'parameterName')")]
-        [InlineData("Invalid enum value", "Invalid enum value")]
-        public void ErrorMessageMatchesExpectedWhenInputIsInt(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<InvalidEnumArgumentException>(
-                () => Guard.Against.EnumOutOfRange<TestEnum>(99, "parameterName", customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData(null, "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedWhenInputIsInt(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<InvalidEnumArgumentException>(
-                () => Guard.Against.EnumOutOfRange<TestEnum>(99, expectedParamName, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+        Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue));
     }
 
 
-    public enum TestEnum
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(6)]
+    [InlineData(10)]
+    public void ThrowsGivenOutOfRangeValue(int enumValue)
     {
-        Cat = 0,
-        Dog = 1,
-        Fish = 2,
-        Budgie = 3,
-        Penguin = 4,
-        Frog = 5
+        var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue)));
+        Assert.Equal(nameof(enumValue), exception.ParamName);
     }
+
+    [Theory]
+    [InlineData(TestEnum.Budgie)]
+    [InlineData(TestEnum.Cat)]
+    [InlineData(TestEnum.Dog)]
+    [InlineData(TestEnum.Fish)]
+    [InlineData(TestEnum.Frog)]
+    [InlineData(TestEnum.Penguin)]
+    public void DoesNothingGivenInRangeEnum(TestEnum enumValue)
+    {
+        Guard.Against.EnumOutOfRange(enumValue, nameof(enumValue));
+    }
+
+
+    [Theory]
+    [InlineData((TestEnum)(-1))]
+    [InlineData((TestEnum)6)]
+    [InlineData((TestEnum)10)]
+    public void ThrowsGivenOutOfRangeEnum(TestEnum enumValue)
+    {
+        var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.EnumOutOfRange(enumValue, nameof(enumValue)));
+        Assert.Equal(nameof(enumValue), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    public void ReturnsExpectedValueGivenInRangeValue(int enumValue)
+    {
+        var expected = enumValue;
+        Assert.Equal(expected, Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue)));
+    }
+
+    [Theory]
+    [InlineData(TestEnum.Budgie)]
+    [InlineData(TestEnum.Cat)]
+    [InlineData(TestEnum.Dog)]
+    [InlineData(TestEnum.Fish)]
+    [InlineData(TestEnum.Frog)]
+    [InlineData(TestEnum.Penguin)]
+    public void ReturnsExpectedValueGivenInRangeEnum(TestEnum enumValue)
+    {
+        var expected = enumValue;
+        Assert.Equal(expected, Guard.Against.EnumOutOfRange(enumValue, nameof(enumValue)));
+    }
+
+    [Theory]
+    [InlineData(null, "The value of argument 'parameterName' (99) is invalid for Enum type 'TestEnum'. (Parameter 'parameterName')")]
+    [InlineData("Invalid enum value", "Invalid enum value")]
+    public void ErrorMessageMatchesExpectedWhenInputIsEnum(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<InvalidEnumArgumentException>(
+            () => Guard.Against.EnumOutOfRange((TestEnum)99, "parameterName", customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "The value of argument 'xyz' (99) is invalid for Enum type 'TestEnum'. (Parameter 'xyz')")]
+    [InlineData("Invalid enum value", "Invalid enum value")]
+    public void ErrorMessageMatchesExpectedWhenInputIsEnumAndParamNameNotExplicitlyProvided(string customMessage, string expectedMessage)
+    {
+        var xyz = (TestEnum)99;
+        var exception = Assert.Throws<InvalidEnumArgumentException>(
+            () => Guard.Against.EnumOutOfRange(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData(null, "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedWhenInputIsEnum(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<InvalidEnumArgumentException>(
+            () => Guard.Against.EnumOutOfRange((TestEnum)99, expectedParamName, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null, "The value of argument 'parameterName' (99) is invalid for Enum type 'TestEnum'. (Parameter 'parameterName')")]
+    [InlineData("Invalid enum value", "Invalid enum value")]
+    public void ErrorMessageMatchesExpectedWhenInputIsInt(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<InvalidEnumArgumentException>(
+            () => Guard.Against.EnumOutOfRange<TestEnum>(99, "parameterName", customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData(null, "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedWhenInputIsInt(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<InvalidEnumArgumentException>(
+            () => Guard.Against.EnumOutOfRange<TestEnum>(99, expectedParamName, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+}
+
+
+public enum TestEnum
+{
+    Cat = 0,
+    Dog = 1,
+    Fish = 2,
+    Budgie = 3,
+    Penguin = 4,
+    Frog = 5
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDecimal.cs
@@ -4,132 +4,131 @@ using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForEnumerableDecimal
 {
-    public class GuardAgainstOutOfRangeForEnumerableDecimal
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void DoesNothingGivenInRangeValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
     {
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void DoesNothingGivenInRangeValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
+        Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsGivenOutOfRangeValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectRangeClassData))]
+    public void ThrowsGivenInvalidArgumentValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
+    {
+        var result = Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+        Assert.Equal(input, result);
+    }
+
+    [Theory]
+    [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = new[] { 0m, 1m, 99m };
+        decimal rangeFrom = 2m;
+        decimal rangeTo = 1m;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = new[] { 0m, 1m, 99m };
+        decimal rangeFrom = 2m;
+        decimal rangeTo = 1m;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = new[] { 0m, 1m, 99m };
+        decimal rangeFrom = 0m;
+        decimal rangeTo = 1m;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = new[] { 0m, 1m, 99m };
+        decimal rangeFrom = 0m;
+        decimal rangeTo = 1m;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    public class CorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+            yield return new object[] { new List<decimal> { decimal.MaxValue, 1.0m, decimal.MinValue }, decimal.MinValue, decimal.MaxValue };
+            yield return new object[] { new List<decimal> { 1100000.0m, 2000.8m, 120.5m, 180000.0m }, 100.0, 1200000.0 };
+            yield return new object[] { new List<decimal> { 0.1m, 128, 200.5m }, 0.1, 200.5 };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectClassData))]
-        public void ThrowsGivenOutOfRangeValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
+    public class IncorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+            yield return new object[] { new List<decimal> { 10.0m, 12.0m, 1500.0m }, 10.0, 1200.0 };
+            yield return new object[] { new List<decimal> { 1000.0m, 200.0m, 120.0m, 180000.0m }, 100.0, 150000.0 };
+            yield return new object[] { new List<decimal> { 5.0m, 120.0m, 158.0m }, 10.1, 110.0 };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void ThrowsGivenInvalidArgumentValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
+    public class IncorrectRangeClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+            yield return new object[] { new List<decimal> { 10000.0m, 1200.0m, 15.0m }, 10000.0, 10.0 };
+            yield return new object[] { new List<decimal> { 100010.0m, 200.0m, 120000.0m, 0.2m }, 2000000.0, 150.0 };
+            yield return new object[] { new List<decimal> { 52000.0m, 86.0m, 2500000.0m }, 20000000.0, 100.0 };
         }
-
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
-        {
-            var result = Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
-            Assert.Equal(input, result);
-        }
-
-        [Theory]
-        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = new[] { 0m, 1m, 99m };
-            decimal rangeFrom = 2m;
-            decimal rangeTo = 1m;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = new[] { 0m, 1m, 99m };
-            decimal rangeFrom = 2m;
-            decimal rangeTo = 1m;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        [Theory]
-        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = new[] { 0m, 1m, 99m };
-            decimal rangeFrom = 0m;
-            decimal rangeTo = 1m;
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = new [] { 0m, 1m, 99m };
-            decimal rangeFrom = 0m;
-            decimal rangeTo = 1m;
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        public class CorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<decimal> { decimal.MaxValue, 1.0m, decimal.MinValue }, decimal.MinValue, decimal.MaxValue };
-                yield return new object[] { new List<decimal> { 1100000.0m, 2000.8m, 120.5m, 180000.0m }, 100.0, 1200000.0 };
-                yield return new object[] { new List<decimal> { 0.1m, 128, 200.5m }, 0.1, 200.5 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<decimal> { 10.0m, 12.0m, 1500.0m }, 10.0, 1200.0 };
-                yield return new object[] { new List<decimal> { 1000.0m, 200.0m, 120.0m, 180000.0m }, 100.0, 150000.0 };
-                yield return new object[] { new List<decimal> { 5.0m, 120.0m, 158.0m }, 10.1, 110.0 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectRangeClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<decimal> { 10000.0m, 1200.0m, 15.0m }, 10000.0, 10.0 };
-                yield return new object[] { new List<decimal> { 100010.0m, 200.0m, 120000.0m, 0.2m }, 2000000.0, 150.0 };
-                yield return new object[] { new List<decimal> { 52000.0m, 86.0m, 2500000.0m }, 20000000.0, 100.0 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDouble.cs
@@ -4,136 +4,135 @@ using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForEnumerableDouble
 {
-    public class GuardAgainstOutOfRangeForEnumerableDouble
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void DoesNothingGivenInRangeValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
     {
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void DoesNothingGivenInRangeValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
-        {
-            Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
-        }
-
-        [Theory]
-        [ClassData(typeof(IncorrectClassData))]
-        public void ThrowsGivenOutOfRangeValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
-        }
-
-        [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void ThrowsGivenInvalidArgumentValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
-        }
-
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
-        {
-            var result = Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
-            Assert.Equal(input, result);
-        }
-
-        [Theory]
-        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = new [] { 0d, 1d, 99d };
-            double rangeFrom = 2d;
-            double rangeTo = 1d;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = new[] { 0d, 1d, 99d };
-            double rangeFrom = 2d;
-            double rangeTo = 1d;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        [Theory]
-        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = new[] { 0d, 1d, 99d };
-            double rangeFrom = 0d;
-            double rangeTo = 1d;
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = new[] { 0d, 1d, 99d };
-            double rangeFrom = 0d;
-            double rangeTo = 1d;
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        public class CorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[]
-                {
-                    new List<double> {double.MaxValue, 1.0, double.MinValue}, double.MinValue, double.MaxValue
-                };
-                yield return new object[] {new List<double> {1100000.0, 2000.8, 120.5, 180000.0}, 100.0, 1200000.0};
-                yield return new object[] {new List<double> {0.1, 128, 200.5}, 0.1, 200.5};
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<double> { 10.0, 12.0, 1500.0 }, 10.0, 1200.0 };
-                yield return new object[] { new List<double> { 1000.0, 200.0, 120.0, 180000.0 }, 100.0, 150000.0 };
-                yield return new object[] { new List<double> { 15.0, 120.0, 158.0 }, 10.1, 110.0 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectRangeClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<double> { 10000.0, 1200.0, 15.0}, 10000.0, 10.0 };
-                yield return new object[] { new List<double> { 100010.0, 200.0, 120000.0, 0.2 }, 2000000.0, 150.0 };
-                yield return new object[] { new List<double> { 52000.0, 86.0, 2500000.0 }, 20000000.0, 100.0 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
+        Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
     }
+
+    [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsGivenOutOfRangeValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectRangeClassData))]
+    public void ThrowsGivenInvalidArgumentValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
+    {
+        var result = Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+        Assert.Equal(input, result);
+    }
+
+    [Theory]
+    [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = new[] { 0d, 1d, 99d };
+        double rangeFrom = 2d;
+        double rangeTo = 1d;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = new[] { 0d, 1d, 99d };
+        double rangeFrom = 2d;
+        double rangeTo = 1d;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = new[] { 0d, 1d, 99d };
+        double rangeFrom = 0d;
+        double rangeTo = 1d;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = new[] { 0d, 1d, 99d };
+        double rangeFrom = 0d;
+        double rangeTo = 1d;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    public class CorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[]
+            {
+                new List<double> {double.MaxValue, 1.0, double.MinValue}, double.MinValue, double.MaxValue
+            };
+            yield return new object[] { new List<double> { 1100000.0, 2000.8, 120.5, 180000.0 }, 100.0, 1200000.0 };
+            yield return new object[] { new List<double> { 0.1, 128, 200.5 }, 0.1, 200.5 };
+        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public class IncorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { new List<double> { 10.0, 12.0, 1500.0 }, 10.0, 1200.0 };
+            yield return new object[] { new List<double> { 1000.0, 200.0, 120.0, 180000.0 }, 100.0, 150000.0 };
+            yield return new object[] { new List<double> { 15.0, 120.0, 158.0 }, 10.1, 110.0 };
+        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public class IncorrectRangeClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { new List<double> { 10000.0, 1200.0, 15.0 }, 10000.0, 10.0 };
+            yield return new object[] { new List<double> { 100010.0, 200.0, 120000.0, 0.2 }, 2000000.0, 150.0 };
+            yield return new object[] { new List<double> { 52000.0, 86.0, 2500000.0 }, 20000000.0, 100.0 };
+        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableFloat.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableFloat.cs
@@ -4,132 +4,131 @@ using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForEnumerableFloat
 {
-    public class GuardAgainstOutOfRangeForEnumerableFloat
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void DoesNothingGivenInRangeValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
     {
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void DoesNothingGivenInRangeValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
+        Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsGivenOutOfRangeValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectRangeClassData))]
+    public void ThrowsGivenInvalidArgumentValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
+    {
+        var result = Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+        Assert.Equal(input, result);
+    }
+
+    [Theory]
+    [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = new[] { 0f, 1f, 99f };
+        float rangeFrom = 2f;
+        float rangeTo = 1f;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = new[] { 0f, 1f, 99f };
+        float rangeFrom = 2f;
+        float rangeTo = 1f;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = new[] { 0f, 1f, 99f };
+        float rangeFrom = 0f;
+        float rangeTo = 1f;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = new[] { 0f, 1f, 99f };
+        float rangeFrom = 0f;
+        float rangeTo = 1f;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    public class CorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+            yield return new object[] { new List<float> { float.MaxValue, 1.0f, float.MinValue }, float.MinValue, float.MaxValue };
+            yield return new object[] { new List<float> { 1100000.0f, 2000.8f, 120.5f, 180000.0f }, 100.0, 1200000.0 };
+            yield return new object[] { new List<float> { 0.1f, 128.0f, 200.5f }, 0.1, 200.5 };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectClassData))]
-        public void ThrowsGivenOutOfRangeValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
+    public class IncorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+            yield return new object[] { new List<float> { 10.0f, 12.0f, 1500.0f }, 10.0, 1200.0 };
+            yield return new object[] { new List<float> { 1000.0f, 200.0f, 120.0f, 180000.0f }, 100.0, 150000.0 };
+            yield return new object[] { new List<float> { 15.0f, 120.0f, 158.0f }, 10.1, 110.0 };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void ThrowsGivenInvalidArgumentValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
+    public class IncorrectRangeClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+            yield return new object[] { new List<float> { 10000.0f, 1200.0f, 15.0f }, 10000.0, 10.0 };
+            yield return new object[] { new List<float> { 100010.0f, 200.0f, 120000.0f, 180.0f }, 2000000.0, 150.0 };
+            yield return new object[] { new List<float> { 52000.0f, 86.0f, 2500000.0f }, 20000000.0, 100.0 };
         }
-
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
-        {
-            var result = Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
-            Assert.Equal(input, result);
-        }
-
-        [Theory]
-        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = new[] { 0f, 1f, 99f };
-            float rangeFrom = 2f;
-            float rangeTo = 1f;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = new[] { 0f, 1f, 99f };
-            float rangeFrom = 2f;
-            float rangeTo = 1f;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        [Theory]
-        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = new[] { 0f, 1f, 99f };
-            float rangeFrom = 0f;
-            float rangeTo = 1f;
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = new[] { 0f, 1f, 99f };
-            float rangeFrom = 0f;
-            float rangeTo = 1f;
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        public class CorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] {new List<float> {float.MaxValue, 1.0f, float.MinValue}, float.MinValue, float.MaxValue};
-                yield return new object[] {new List<float> {1100000.0f, 2000.8f, 120.5f, 180000.0f}, 100.0,1200000.0};
-                yield return new object[] {new List<float> {0.1f, 128.0f, 200.5f}, 0.1, 200.5};
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<float> { 10.0f, 12.0f, 1500.0f }, 10.0, 1200.0 };
-                yield return new object[] { new List<float> { 1000.0f, 200.0f, 120.0f, 180000.0f }, 100.0, 150000.0 };
-                yield return new object[] { new List<float> { 15.0f, 120.0f, 158.0f }, 10.1, 110.0 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectRangeClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<float> { 10000.0f, 1200.0f, 15.0f }, 10000.0, 10.0 };
-                yield return new object[] { new List<float> { 100010.0f, 200.0f, 120000.0f, 180.0f }, 2000000.0, 150.0 };
-                yield return new object[] { new List<float> { 52000.0f, 86.0f, 2500000.0f }, 20000000.0, 100.0 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableInt.cs
@@ -4,132 +4,131 @@ using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForEnumerableInt
 {
-    public class GuardAgainstOutOfRangeForEnumerableInt
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void DoesNothingGivenInRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
     {
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void DoesNothingGivenInRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+        Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsGivenOutOfRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectRangeClassData))]
+    public void ThrowsGivenInvalidArgumentValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+    {
+        var result = Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+        Assert.Equal(input, result);
+    }
+
+    [Theory]
+    [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = new[] { 0, 1, 99 };
+        int rangeFrom = 2;
+        int rangeTo = 1;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = new[] { 0, 1, 99 };
+        int rangeFrom = 2;
+        int rangeTo = 1;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = new[] { 0, 1, 99 };
+        int rangeFrom = 0;
+        int rangeTo = 1;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = new[] { 0, 1, 99 };
+        int rangeFrom = 0;
+        int rangeTo = 1;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    public class CorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+            yield return new object[] { new List<int> { 1000, 1200, 1500 }, 1000, 2000 };
+            yield return new object[] { new List<int> { 100000, 2000, 120, 180000 }, 100, 200000 };
+            yield return new object[] { new List<int> { 18, 128, 108 }, 0, 200 };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectClassData))]
-        public void ThrowsGivenOutOfRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+    public class IncorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+            yield return new object[] { new List<int> { 10, 12, 1500 }, 10, 1200 };
+            yield return new object[] { new List<int> { 1000, 200, 120, 180000 }, 100, 150000 };
+            yield return new object[] { new List<int> { 15, 120, 158 }, 10, 110 };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void ThrowsGivenInvalidArgumentValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+    public class IncorrectRangeClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+            yield return new object[] { new List<int> { 10000, 1200, 15 }, 10000, 10 };
+            yield return new object[] { new List<int> { 100010, 200, 120000, 180 }, 2000000, 150 };
+            yield return new object[] { new List<int> { 52000, 86, 2500000 }, 20000000, 100 };
         }
-
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
-        {
-            var result = Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
-            Assert.Equal(input, result);
-        }
-
-        [Theory]
-        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = new[] { 0, 1, 99 };
-            int rangeFrom = 2;
-            int rangeTo = 1;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = new[] { 0, 1, 99 };
-            int rangeFrom = 2;
-            int rangeTo = 1;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        [Theory]
-        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = new[] { 0, 1, 99 };
-            int rangeFrom = 0;
-            int rangeTo = 1;
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = new[] { 0, 1, 99 };
-            int rangeFrom = 0;
-            int rangeTo = 1;
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        public class CorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<int> { 1000, 1200, 1500 }, 1000, 2000 };
-                yield return new object[] { new List<int> { 100000, 2000, 120, 180000 }, 100, 200000 };
-                yield return new object[] { new List<int> { 18, 128, 108 }, 0, 200 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<int> { 10, 12, 1500 }, 10, 1200 };
-                yield return new object[] { new List<int> { 1000, 200, 120, 180000 }, 100, 150000 };
-                yield return new object[] { new List<int> { 15, 120, 158 }, 10, 110 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectRangeClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<int> { 10000, 1200, 15 }, 10000, 10 };
-                yield return new object[] { new List<int> { 100010, 200, 120000, 180 }, 2000000, 150 };
-                yield return new object[] { new List<int> { 52000, 86, 2500000 }, 20000000, 100 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableLong.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableLong.cs
@@ -4,132 +4,131 @@ using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForEnumerableLong
 {
-    public class GuardAgainstOutOfRangeForEnumerableLong
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void DoesNothingGivenInRangeValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
     {
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void DoesNothingGivenInRangeValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
+        Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsGivenOutOfRangeValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectRangeClassData))]
+    public void ThrowsGivenInvalidArgumentValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
+    {
+        var result = Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+        Assert.Equal(input, result);
+    }
+
+    [Theory]
+    [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = new long[] { 0, 1, 99 };
+        long rangeFrom = 2;
+        long rangeTo = 1;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = new long[] { 0, 1, 99 };
+        long rangeFrom = 2;
+        long rangeTo = 1;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = new long[] { 0, 1, 99 };
+        long rangeFrom = 0;
+        long rangeTo = 1;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = new long[] { 0, 1, 99 };
+        long rangeFrom = 0;
+        long rangeTo = 1;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    public class CorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+            yield return new object[] { new List<long> { long.MaxValue, 1200, long.MinValue }, long.MinValue, long.MaxValue };
+            yield return new object[] { new List<long> { 1100000, 2000, 120, 180000 }, 100, 1200000 };
+            yield return new object[] { new List<long> { 18, 128, 108 }, 0, 200 };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectClassData))]
-        public void ThrowsGivenOutOfRangeValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
+    public class IncorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+            yield return new object[] { new List<long> { 10, 12, 1500 }, 10, 1200 };
+            yield return new object[] { new List<long> { 1000, 200, 120, 180000 }, 100, 150000 };
+            yield return new object[] { new List<long> { 15, 120, 158 }, 10, 110 };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void ThrowsGivenInvalidArgumentValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
+    public class IncorrectRangeClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+            yield return new object[] { new List<long> { 10000, 1200, 15 }, 10000, 10 };
+            yield return new object[] { new List<long> { 100010, 200, 120000, 180 }, 2000000, 150 };
+            yield return new object[] { new List<long> { 52000, 86, 2500000 }, 20000000, 100 };
         }
-
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
-        {
-            var result = Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
-            Assert.Equal(input, result);
-        }
-
-        [Theory]
-        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = new long[] { 0, 1, 99 };
-            long rangeFrom = 2;
-            long rangeTo = 1;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = new long[] { 0, 1, 99 };
-            long rangeFrom = 2;
-            long rangeTo = 1;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        [Theory]
-        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = new long[] { 0, 1, 99 };
-            long rangeFrom = 0;
-            long rangeTo = 1;
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = new long[] { 0, 1, 99 };
-            long rangeFrom = 0;
-            long rangeTo = 1;
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        public class CorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<long> { long.MaxValue, 1200, long.MinValue}, long.MinValue, long.MaxValue };
-                yield return new object[] { new List<long> { 1100000, 2000, 120, 180000 }, 100, 1200000 };
-                yield return new object[] { new List<long> { 18, 128, 108 }, 0, 200 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<long> { 10, 12, 1500 }, 10, 1200 };
-                yield return new object[] { new List<long> { 1000, 200, 120, 180000 }, 100, 150000 };
-                yield return new object[] { new List<long> { 15, 120, 158 }, 10, 110 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectRangeClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<long> { 10000, 1200, 15 }, 10000, 10 };
-                yield return new object[] { new List<long> { 100010, 200, 120000, 180 }, 2000000, 150 };
-                yield return new object[] { new List<long> { 52000, 86, 2500000 }, 20000000, 100 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableShort.cs
@@ -4,132 +4,131 @@ using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForEnumerableShort
 {
-    public class GuardAgainstOutOfRangeForEnumerableShort
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void DoesNothingGivenInRangeValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
     {
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void DoesNothingGivenInRangeValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
+        Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsGivenOutOfRangeValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectRangeClassData))]
+    public void ThrowsGivenInvalidArgumentValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
+    {
+        var result = Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+        Assert.Equal(input, result);
+    }
+
+    [Theory]
+    [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = new short[] { 0, 1, 99 };
+        short rangeFrom = 2;
+        short rangeTo = 1;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = new short[] { 0, 1, 99 };
+        short rangeFrom = 2;
+        short rangeTo = 1;
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = new short[] { 0, 1, 99 };
+        short rangeFrom = 0;
+        short rangeTo = 1;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = new short[] { 0, 1, 99 };
+        short rangeFrom = 0;
+        short rangeTo = 1;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    public class CorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
+            yield return new object[] { new List<short> { 10, 12, 15 }, 10, 20 };
+            yield return new object[] { new List<short> { 100, 200, 120, 180 }, 100, 200 };
+            yield return new object[] { new List<short> { 18, 128, 108 }, 0, 200 };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectClassData))]
-        public void ThrowsGivenOutOfRangeValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
+    public class IncorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+            yield return new object[] { new List<short> { 10, 12, 15 }, 10, 12 };
+            yield return new object[] { new List<short> { 100, 200, 120, 180 }, 100, 150 };
+            yield return new object[] { new List<short> { 15, 120, 158 }, 10, 110 };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void ThrowsGivenInvalidArgumentValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
+    public class IncorrectRangeClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+            yield return new object[] { new List<short> { 10, 12, 15 }, 10, 9 };
+            yield return new object[] { new List<short> { 100, 200, 120, 180 }, 200, 150 };
+            yield return new object[] { new List<short> { 52, 86, 250 }, 200, 100 };
         }
-
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
-        {
-            var result = Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo);
-            Assert.Equal(input, result);
-        }
-
-        [Theory]
-        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = new short[] { 0, 1, 99 };
-            short rangeFrom = 2;
-            short rangeTo = 1;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = new short[] { 0, 1, 99 };
-            short rangeFrom = 2;
-            short rangeTo = 1;
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        [Theory]
-        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = new short[] { 0, 1, 99 };
-            short rangeFrom = 0;
-            short rangeTo = 1;
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = new short[] { 0, 1, 99 };
-            short rangeFrom = 0;
-            short rangeTo = 1;
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        public class CorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<short> { 10, 12, 15 }, 10, 20 };
-                yield return new object[] { new List<short> { 100, 200, 120, 180 }, 100, 200 };
-                yield return new object[] { new List<short> { 18, 128, 108 }, 0, 200 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<short> { 10, 12, 15 }, 10, 12 };
-                yield return new object[] { new List<short> { 100, 200, 120, 180 }, 100, 150 };
-                yield return new object[] { new List<short> { 15, 120, 158 }, 10, 110 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectRangeClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<short> { 10, 12, 15 }, 10, 9 };
-                yield return new object[] { new List<short> { 100, 200, 120, 180 }, 200, 150 };
-                yield return new object[] { new List<short> { 52, 86, 250 }, 200, 100 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableTimeSpan.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableTimeSpan.cs
@@ -5,148 +5,147 @@ using System.Linq;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForEnumerableTimeSpan
 {
-    public class GuardAgainstOutOfRangeForEnumerableTimeSpan
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void DoesNothingGivenInRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
     {
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void DoesNothingGivenInRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+        var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+
+        Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan);
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsGivenOutOfRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+    {
+        var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan));
+    }
+
+    [Theory]
+    [ClassData(typeof(IncorrectRangeClassData))]
+    public void ThrowsGivenInvalidArgumentValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+    {
+        var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan));
+    }
+
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+    {
+        var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+
+        var result = Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan);
+        Assert.Equal(inputTimeSpan, result);
+    }
+
+    [Theory]
+    [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = Enumerable.Range(0, 3).Select(i => TimeSpan.FromSeconds(i));
+        var rangeFrom = TimeSpan.FromSeconds(2);
+        var rangeTo = TimeSpan.FromSeconds(1);
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = Enumerable.Range(0, 3).Select(i => TimeSpan.FromSeconds(i));
+        var rangeFrom = TimeSpan.FromSeconds(2);
+        var rangeTo = TimeSpan.FromSeconds(1);
+
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+    {
+        var input = Enumerable.Range(0, 3).Select(i => TimeSpan.FromSeconds(i));
+        var rangeFrom = TimeSpan.FromSeconds(0);
+        var rangeTo = TimeSpan.FromSeconds(1);
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+    {
+        var input = Enumerable.Range(0, 3).Select(i => TimeSpan.FromSeconds(i));
+        var rangeFrom = TimeSpan.FromSeconds(0);
+        var rangeTo = TimeSpan.FromSeconds(1);
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    public class CorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
-
-            Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan);
+            yield return new object[] { new List<int> { 1000, 1200, 1500 }, 1000, 2000 };
+            yield return new object[] { new List<int> { 100000, 2000, 120, 180000 }, 100, 200000 };
+            yield return new object[] { new List<int> { 18, 128, 108 }, 0, 200 };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectClassData))]
-        public void ThrowsGivenOutOfRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+    public class IncorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan));
+            yield return new object[] { new List<int> { 10, 12, 1500 }, 10, 1200 };
+            yield return new object[] { new List<int> { 1000, 200, 120, 180000 }, 100, 150000 };
+            yield return new object[] { new List<int> { 15, 120, 158 }, 10, 110 };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectRangeClassData))]
-        public void ThrowsGivenInvalidArgumentValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+    public class IncorrectRangeClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
-
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan));
+            yield return new object[] { new List<int> { 10000, 1200, 15 }, 10000, 10 };
+            yield return new object[] { new List<int> { 100010, 200, 120000, 180 }, 2000000, 150 };
+            yield return new object[] { new List<int> { 52000, 86, 2500000 }, 20000000, 100 };
         }
-
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void ReturnsExpectedValueGivenInRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
-        {
-            var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
-
-            var result = Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan);
-            Assert.Equal(inputTimeSpan, result);
-        }
-
-        [Theory]
-        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = Enumerable.Range(0, 3).Select(i => TimeSpan.FromSeconds(i));
-            var rangeFrom = TimeSpan.FromSeconds(2);
-            var rangeTo = TimeSpan.FromSeconds(1);
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = Enumerable.Range(0, 3).Select(i => TimeSpan.FromSeconds(i));
-            var rangeFrom = TimeSpan.FromSeconds(2);
-            var rangeTo = TimeSpan.FromSeconds(1);
-
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        [Theory]
-        [InlineData(null, "Input parameterName had out of range item(s) (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
-        {
-            var input = Enumerable.Range(0, 3).Select(i => TimeSpan.FromSeconds(i));
-            var rangeFrom = TimeSpan.FromSeconds(0);
-            var rangeTo = TimeSpan.FromSeconds(1);
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "parameterName", rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
-        {
-            var input = Enumerable.Range(0, 3).Select(i => TimeSpan.FromSeconds(i));
-            var rangeFrom = TimeSpan.FromSeconds(0);
-            var rangeTo = TimeSpan.FromSeconds(1);
-
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, expectedParamName, rangeFrom, rangeTo, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
-
-        public class CorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<int> { 1000, 1200, 1500 }, 1000, 2000 };
-                yield return new object[] { new List<int> { 100000, 2000, 120, 180000 }, 100, 200000 };
-                yield return new object[] { new List<int> { 18, 128, 108 }, 0, 200 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<int> { 10, 12, 1500 }, 10, 1200 };
-                yield return new object[] { new List<int> { 1000, 200, 120, 180000 }, 100, 150000 };
-                yield return new object[] { new List<int> { 15, 120, 158 }, 10, 110 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class IncorrectRangeClassData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new List<int> { 10000, 1200, 15 }, 10000, 10 };
-                yield return new object[] { new List<int> { 100010, 200, 120000, 180 }, 2000000, 150 };
-                yield return new object[] { new List<int> { 52000, 86, 2500000 }, 20000000, 100 };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
@@ -2,69 +2,68 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForFloat
 {
-    public class GuardAgainstOutOfRangeForFloat
+    [Theory]
+    [InlineData(1.0, 1.0, 1.0)]
+    [InlineData(1.0, 1.0, 3.0)]
+    [InlineData(2.0, 1.0, 3.0)]
+    [InlineData(3.0, 1.0, 3.0)]
+    public void DoesNothingGivenInRangeValue(float input, float rangeFrom, float rangeTo)
     {
-        [Theory]
-        [InlineData(1.0, 1.0, 1.0)]
-        [InlineData(1.0, 1.0, 3.0)]
-        [InlineData(2.0, 1.0, 3.0)]
-        [InlineData(3.0, 1.0, 3.0)]
-        public void DoesNothingGivenInRangeValue(float input, float rangeFrom, float rangeTo)
-        {
-            Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
-        }
+        Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
+    }
 
-        [Theory]
-        [InlineData(-1.0, 1.0, 3.0)]
-        [InlineData(0.0, 1.0, 3.0)]
-        [InlineData(4.0, 1.0, 3.0)]
-        public void ThrowsGivenOutOfRangeValue(float input, float rangeFrom, float rangeTo)
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(-1.0, 1.0, 3.0)]
+    [InlineData(0.0, 1.0, 3.0)]
+    [InlineData(4.0, 1.0, 3.0)]
+    public void ThrowsGivenOutOfRangeValue(float input, float rangeFrom, float rangeTo)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(-1.0, 3.0, 1.0)]
-        [InlineData(0.0, 3.0, 1.0)]
-        [InlineData(4.0, 3.0, 1.0)]
-        public void ThrowsGivenInvalidArgumentValue(float input, float rangeFrom, float rangeTo)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(-1.0, 3.0, 1.0)]
+    [InlineData(0.0, 3.0, 1.0)]
+    [InlineData(4.0, 3.0, 1.0)]
+    public void ThrowsGivenInvalidArgumentValue(float input, float rangeFrom, float rangeTo)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(1.0, 1.0, 1.0, 1.0)]
-        [InlineData(1.0, 1.0, 3.0, 1.0)]
-        [InlineData(2.0, 1.0, 3.0, 2.0)]
-        [InlineData(3.0, 1.0, 3.0, 3.0)]
-        public void ReturnsExpectedValueGivenInRangeValue(float input, float rangeFrom, float rangeTo, float expected)
-        {
-            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(1.0, 1.0, 1.0, 1.0)]
+    [InlineData(1.0, 1.0, 3.0, 1.0)]
+    [InlineData(2.0, 1.0, 3.0, 2.0)]
+    [InlineData(3.0, 1.0, 3.0, 3.0)]
+    public void ReturnsExpectedValueGivenInRangeValue(float input, float rangeFrom, float rangeTo, float expected)
+    {
+        Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Float range", "Float range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0f, "parameterName", 0.0f, 1.0f, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
+    [InlineData("Float range", "Float range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0f, "parameterName", 0.0f, 1.0f, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0f, expectedParamName, 0.0f, 1.0f, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3.0f, expectedParamName, 0.0f, 1.0f, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForIComparable.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForIComparable.cs
@@ -2,75 +2,74 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+/// <summary>
+/// Every type that implements IComparable and IComparable<T> can use OutOfRange.
+/// Here for example tuples are used.
+/// </summary>
+public class GuardAgainstOutOfRangeForIComparable
 {
-    /// <summary>
-    /// Every type that implements IComparable and IComparable<T> can use OutOfRange.
-    /// Here for example tuples are used.
-    /// </summary>
-    public class GuardAgainstOutOfRangeForIComparable
+    [Theory]
+    [InlineData(1, 1, 1, 1, 10, 10)]
+    [InlineData(5, 5, 1, 1, 10, 10)]
+    [InlineData(10, 10, 1, 1, 10, 10)]
+    public void DoesNothingGivenInRangeValue(int input1, int input2, int rangeFrom1, int rangeFrom2, int rangeTo1, int rangeTo2)
     {
-        [Theory]
-        [InlineData(1, 1, 1, 1, 10, 10)]
-        [InlineData(5, 5, 1, 1, 10, 10)]
-        [InlineData(10, 10, 1, 1, 10, 10)]
-        public void DoesNothingGivenInRangeValue(int input1, int input2, int rangeFrom1, int rangeFrom2, int rangeTo1, int rangeTo2)
-        {
-            Guard.Against.OutOfRange((input1, input2), "tuple", (rangeFrom1, rangeFrom2), (rangeTo1, rangeTo2));
-        }
+        Guard.Against.OutOfRange((input1, input2), "tuple", (rangeFrom1, rangeFrom2), (rangeTo1, rangeTo2));
+    }
 
-        [Theory]
-        [InlineData(0, 1, 1, 1, 10, 10)]
-        [InlineData(1, 0, 1, 1, 10, 10)]
-        [InlineData(10, 11, 1, 1, 10, 10)]
-        [InlineData(11, 10, 1, 1, 10, 10)]
-        public void ThrowsGivenOutOfRangeValue(int input1, int input2, int rangeFrom1, int rangeFrom2, int rangeTo1, int rangeTo2)
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((input1, input2), "tuple", (rangeFrom1, rangeFrom2), (rangeTo1, rangeTo2)));
-        }
+    [Theory]
+    [InlineData(0, 1, 1, 1, 10, 10)]
+    [InlineData(1, 0, 1, 1, 10, 10)]
+    [InlineData(10, 11, 1, 1, 10, 10)]
+    [InlineData(11, 10, 1, 1, 10, 10)]
+    public void ThrowsGivenOutOfRangeValue(int input1, int input2, int rangeFrom1, int rangeFrom2, int rangeTo1, int rangeTo2)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((input1, input2), "tuple", (rangeFrom1, rangeFrom2), (rangeTo1, rangeTo2)));
+    }
 
-        [Theory]
-        [InlineData(0, 1, 10, 10, 1, 1)]
-        [InlineData(1, 0, 10, 10, 1, 1)]
-        [InlineData(10, 11, 10, 10, 1, 1)]
-        [InlineData(11, 10, 10, 10, 1, 1)]
-        public void ThrowsGivenInvalidArgumentValue(int input1, int input2, int rangeFrom1, int rangeFrom2, int rangeTo1, int rangeTo2)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange((input1, input2), "tuple", (rangeFrom1, rangeFrom2), (rangeTo1, rangeTo2)));
-        }
+    [Theory]
+    [InlineData(0, 1, 10, 10, 1, 1)]
+    [InlineData(1, 0, 10, 10, 1, 1)]
+    [InlineData(10, 11, 10, 10, 1, 1)]
+    [InlineData(11, 10, 10, 10, 1, 1)]
+    public void ThrowsGivenInvalidArgumentValue(int input1, int input2, int rangeFrom1, int rangeFrom2, int rangeTo1, int rangeTo2)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange((input1, input2), "tuple", (rangeFrom1, rangeFrom2), (rangeTo1, rangeTo2)));
+    }
 
-        [Theory]
-        [InlineData(1, 1, 1, 1, 10, 10)]
-        [InlineData(5, 5, 1, 1, 10, 10)]
-        [InlineData(10, 10, 1, 1, 10, 10)]
-        public void ReturnsExpectedValueGivenInRangeValue(int input1, int input2, int rangeFrom1, int rangeFrom2, int rangeTo1, int rangeTo2)
-        {
-            var input = (input1, input2);
-            var actual = Guard.Against.OutOfRange(input, "tuple", (rangeFrom1, rangeFrom2), (rangeTo1, rangeTo2));
-            Assert.Equal(input, actual);
-        }
+    [Theory]
+    [InlineData(1, 1, 1, 1, 10, 10)]
+    [InlineData(5, 5, 1, 1, 10, 10)]
+    [InlineData(10, 10, 1, 1, 10, 10)]
+    public void ReturnsExpectedValueGivenInRangeValue(int input1, int input2, int rangeFrom1, int rangeFrom2, int rangeTo1, int rangeTo2)
+    {
+        var input = (input1, input2);
+        var actual = Guard.Against.OutOfRange(input, "tuple", (rangeFrom1, rangeFrom2), (rangeTo1, rangeTo2));
+        Assert.Equal(input, actual);
+    }
 
-        [Theory]
-        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Tuple range", "Tuple range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((1,2), "parameterName", (3,3), (9,9), customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
+    [InlineData("Tuple range", "Tuple range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((1, 2), "parameterName", (3, 3), (9, 9), customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((1, 2), expectedParamName, (3, 3), (9, 9), customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((1, 2), expectedParamName, (3, 3), (9, 9), customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
@@ -2,69 +2,68 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForInt
 {
-    public class GuardAgainstOutOfRangeForInt
+    [Theory]
+    [InlineData(1, 1, 1)]
+    [InlineData(1, 1, 3)]
+    [InlineData(2, 1, 3)]
+    [InlineData(3, 1, 3)]
+    public void DoesNothingGivenInRangeValue(int input, int rangeFrom, int rangeTo)
     {
-        [Theory]
-        [InlineData(1, 1, 1)]
-        [InlineData(1, 1, 3)]
-        [InlineData(2, 1, 3)]
-        [InlineData(3, 1, 3)]
-        public void DoesNothingGivenInRangeValue(int input, int rangeFrom, int rangeTo)
-        {
-            Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
-        }
+        Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
+    }
 
-        [Theory]
-        [InlineData(-1, 1, 3)]
-        [InlineData(0, 1, 3)]
-        [InlineData(4, 1, 3)]
-        public void ThrowsGivenOutOfRangeValue(int input, int rangeFrom, int rangeTo)
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(-1, 1, 3)]
+    [InlineData(0, 1, 3)]
+    [InlineData(4, 1, 3)]
+    public void ThrowsGivenOutOfRangeValue(int input, int rangeFrom, int rangeTo)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(-1, 3, 1)]
-        [InlineData(0, 3, 1)]
-        [InlineData(4, 3, 1)]
-        public void ThrowsGivenInvalidArgumentValue(int input, int rangeFrom, int rangeTo)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(-1, 3, 1)]
+    [InlineData(0, 3, 1)]
+    [InlineData(4, 3, 1)]
+    public void ThrowsGivenInvalidArgumentValue(int input, int rangeFrom, int rangeTo)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(1, 1, 1, 1)]
-        [InlineData(1, 1, 3, 1)]
-        [InlineData(2, 1, 3, 2)]
-        [InlineData(3, 1, 3, 3)]
-        public void ReturnsExpectedValueGivenInRangeValue(int input, int rangeFrom, int rangeTo, int expected)
-        {
-            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(1, 1, 1, 1)]
+    [InlineData(1, 1, 3, 1)]
+    [InlineData(2, 1, 3, 2)]
+    [InlineData(3, 1, 3, 3)]
+    public void ReturnsExpectedValueGivenInRangeValue(int input, int rangeFrom, int rangeTo, int expected)
+    {
+        Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Int range", "Int range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3, "parameterName", 0, 1, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
+    [InlineData("Int range", "Int range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3, "parameterName", 0, 1, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3, expectedParamName, 0, 1, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(3, expectedParamName, 0, 1, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInvalidInput.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInvalidInput.cs
@@ -5,87 +5,86 @@ using Ardalis.GuardClauses;
 using Microsoft.VisualBasic;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForInvalidInput
 {
-    public class GuardAgainstOutOfRangeForInvalidInput
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void DoesNothingGivenInRangeValue<T>(T input, Func<T, bool> func)
     {
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void DoesNothingGivenInRangeValue<T>(T input, Func<T, bool> func)
-        {
-            Guard.Against.InvalidInput(input, nameof(input), func);
-        }
+        Guard.Against.InvalidInput(input, nameof(input), func);
+    }
 
-        [Theory]
-        [ClassData(typeof(IncorrectClassData))]
-        public void ThrowsGivenOutOfRangeValue<T>(T input, Func<T, bool> func)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.InvalidInput(input, nameof(input), func));
-        }
+    [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsGivenOutOfRangeValue<T>(T input, Func<T, bool> func)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.InvalidInput(input, nameof(input), func));
+    }
 
-        [Theory]
-        [ClassData(typeof(CorrectClassData))]
-        public void ReturnsExpectedValueGivenInRangeValue<T>(T input, Func<T, bool> func)
-        {
-            var result = Guard.Against.InvalidInput(input, nameof(input), func);
-            Assert.Equal(input, result);
-        }
+    [Theory]
+    [ClassData(typeof(CorrectClassData))]
+    public void ReturnsExpectedValueGivenInRangeValue<T>(T input, Func<T, bool> func)
+    {
+        var result = Guard.Against.InvalidInput(input, nameof(input), func);
+        Assert.Equal(input, result);
+    }
 
-        [Theory]
-        [InlineData(null, "Input parameterName did not satisfy the options (Parameter 'parameterName')")]
-        [InlineData("Evaluation failed", "Evaluation failed (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidInput(10, "parameterName", x => x > 20, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Input parameterName did not satisfy the options (Parameter 'parameterName')")]
+    [InlineData("Evaluation failed", "Evaluation failed (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidInput(10, "parameterName", x => x > 20, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidInput(10, expectedParamName, x => x > 20, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidInput(10, expectedParamName, x => x > 20, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
 
-        // TODO: Test decimal types outside of ClassData
-        // See: https://github.com/xunit/xunit/issues/2298
-        public class CorrectClassData : IEnumerable<object[]>
+    // TODO: Test decimal types outside of ClassData
+    // See: https://github.com/xunit/xunit/issues/2298
+    public class CorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { 20, (Func<int, bool>)((x) => x > 10) };
-                yield return new object[] { DateAndTime.Now, (Func<DateTime, bool>)((x) => x > DateTime.MinValue) };
-                yield return new object[] { 20.0f, (Func<float, bool>)((x) => x > 10.0f) };
-                //yield return new object[] { 20.0m, (Func<decimal, bool>)((x) => x > 10.0m) };
-                yield return new object[] { 20.0, (Func<double, bool>)((x) => x > 10.0) };
-                yield return new object[] { long.MaxValue, (Func<long, bool>)((x) => x > 1) };
-                yield return new object[] { short.MaxValue, (Func<short, bool>)((x) => x > 1) };
-                yield return new object[] { "abcd", (Func<string, bool>)((x) => x == x.ToLower()) };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            yield return new object[] { 20, (Func<int, bool>)((x) => x > 10) };
+            yield return new object[] { DateAndTime.Now, (Func<DateTime, bool>)((x) => x > DateTime.MinValue) };
+            yield return new object[] { 20.0f, (Func<float, bool>)((x) => x > 10.0f) };
+            //yield return new object[] { 20.0m, (Func<decimal, bool>)((x) => x > 10.0m) };
+            yield return new object[] { 20.0, (Func<double, bool>)((x) => x > 10.0) };
+            yield return new object[] { long.MaxValue, (Func<long, bool>)((x) => x > 1) };
+            yield return new object[] { short.MaxValue, (Func<short, bool>)((x) => x > 1) };
+            yield return new object[] { "abcd", (Func<string, bool>)((x) => x == x.ToLower()) };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
-        public class IncorrectClassData : IEnumerable<object[]>
+    public class IncorrectClassData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
         {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { 20, (Func<int, bool>)((x) => x < 10) };
-                yield return new object[] { DateAndTime.Now, (Func<DateTime, bool>)((x) => x > DateTime.MaxValue) };
-                yield return new object[] { 20.0f, (Func<float, bool>)((x) => x > 30.0f) };
-                //yield return new object[] { 20.0m, (Func<decimal, bool>)((x) => x > 30.0m) };
-                yield return new object[] { 20.0, (Func<double, bool>)((x) => x > 30.0) };
-                yield return new object[] { long.MaxValue, (Func<long, bool>)((x) => x < 1) };
-                yield return new object[] { short.MaxValue, (Func<short, bool>)((x) => x < 1) };
-                yield return new object[] { "abcd", (Func<string, bool>)((x) => x == x.ToUpper()) };
-            }
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            yield return new object[] { 20, (Func<int, bool>)((x) => x < 10) };
+            yield return new object[] { DateAndTime.Now, (Func<DateTime, bool>)((x) => x > DateTime.MaxValue) };
+            yield return new object[] { 20.0f, (Func<float, bool>)((x) => x > 30.0f) };
+            //yield return new object[] { 20.0m, (Func<decimal, bool>)((x) => x > 30.0m) };
+            yield return new object[] { 20.0, (Func<double, bool>)((x) => x > 30.0) };
+            yield return new object[] { long.MaxValue, (Func<long, bool>)((x) => x < 1) };
+            yield return new object[] { short.MaxValue, (Func<short, bool>)((x) => x < 1) };
+            yield return new object[] { "abcd", (Func<string, bool>)((x) => x == x.ToUpper()) };
         }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
@@ -2,69 +2,68 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForShort
 {
-    public class GuardAgainstOutOfRangeForShort
+    [Theory]
+    [InlineData(1, 1, 1)]
+    [InlineData(1, 1, 3)]
+    [InlineData(2, 1, 3)]
+    [InlineData(3, 1, 3)]
+    public void DoesNothingGivenInRangeValue(short input, short rangeFrom, short rangeTo)
     {
-        [Theory]
-        [InlineData(1, 1, 1)]
-        [InlineData(1, 1, 3)]
-        [InlineData(2, 1, 3)]
-        [InlineData(3, 1, 3)]
-        public void DoesNothingGivenInRangeValue(short input, short rangeFrom, short rangeTo)
-        {
-            Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
-        }
+        Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
+    }
 
-        [Theory]
-        [InlineData(-1, 1, 3)]
-        [InlineData(0, 1, 3)]
-        [InlineData(4, 1, 3)]
-        public void ThrowsGivenOutOfRangeValue(short input, short rangeFrom, short rangeTo)
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(-1, 1, 3)]
+    [InlineData(0, 1, 3)]
+    [InlineData(4, 1, 3)]
+    public void ThrowsGivenOutOfRangeValue(short input, short rangeFrom, short rangeTo)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(-1, 3, 1)]
-        [InlineData(0, 3, 1)]
-        [InlineData(4, 3, 1)]
-        public void ThrowsGivenInvalidArgumentValue(short input, short rangeFrom, short rangeTo)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(-1, 3, 1)]
+    [InlineData(0, 3, 1)]
+    [InlineData(4, 3, 1)]
+    public void ThrowsGivenInvalidArgumentValue(short input, short rangeFrom, short rangeTo)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(1, 1, 1, 1)]
-        [InlineData(1, 1, 3, 1)]
-        [InlineData(2, 1, 3, 2)]
-        [InlineData(3, 1, 3, 3)]
-        public void ReturnsExpectedValueGivenInRangeValue(short input, short rangeFrom, short rangeTo, short expected)
-        {
-            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(1, 1, 1, 1)]
+    [InlineData(1, 1, 3, 1)]
+    [InlineData(2, 1, 3, 2)]
+    [InlineData(3, 1, 3, 3)]
+    public void ReturnsExpectedValueGivenInRangeValue(short input, short rangeFrom, short rangeTo, short expected)
+    {
+        Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Short range", "Short range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((short) 3, "parameterName", (short) 0, (short) 1, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
+    [InlineData("Short range", "Short range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((short)3, "parameterName", (short)0, (short)1, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((short)3, expectedParamName, (short)0, (short)1, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((short)3, expectedParamName, (short)0, (short)1, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForTimeSpan.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForTimeSpan.cs
@@ -2,125 +2,124 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForTimeSpan
 {
-    public class GuardAgainstOutOfRangeForTimeSpan
+    [Theory]
+    [InlineData(1, 1, 1)]
+    [InlineData(1, 1, 3)]
+    [InlineData(2, 1, 3)]
+    [InlineData(3, 1, 3)]
+    public void DoesNothingGivenInRangeValue(int input, int rangeFrom, int rangeTo)
     {
-        [Theory]
-        [InlineData(1, 1, 1)]
-        [InlineData(1, 1, 3)]
-        [InlineData(2, 1, 3)]
-        [InlineData(3, 1, 3)]
-        public void DoesNothingGivenInRangeValue(int input, int rangeFrom, int rangeTo)
-        {
-            var inputTimeSpan = TimeSpan.FromSeconds(input);
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+        var inputTimeSpan = TimeSpan.FromSeconds(input);
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
 
-            Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan);
-        }
+        Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan);
+    }
 
-        [Theory]
-        [InlineData(-1, 1, 3)]
-        [InlineData(0, 1, 3)]
-        [InlineData(4, 1, 3)]
-        public void ThrowsGivenOutOfRangeValue(int input, int rangeFrom, int rangeTo)
-        {
-            var inputTimeSpan = TimeSpan.FromSeconds(input);
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+    [Theory]
+    [InlineData(-1, 1, 3)]
+    [InlineData(0, 1, 3)]
+    [InlineData(4, 1, 3)]
+    public void ThrowsGivenOutOfRangeValue(int input, int rangeFrom, int rangeTo)
+    {
+        var inputTimeSpan = TimeSpan.FromSeconds(input);
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan));
-        }
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan));
+    }
 
-        [Theory]
-        [InlineData(-1, 3, 1)]
-        [InlineData(0, 3, 1)]
-        [InlineData(4, 3, 1)]
-        public void ThrowsGivenInvalidArgumentValue(int input, int rangeFrom, int rangeTo)
-        {
-            var inputTimeSpan = TimeSpan.FromSeconds(input);
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+    [Theory]
+    [InlineData(-1, 3, 1)]
+    [InlineData(0, 3, 1)]
+    [InlineData(4, 3, 1)]
+    public void ThrowsGivenInvalidArgumentValue(int input, int rangeFrom, int rangeTo)
+    {
+        var inputTimeSpan = TimeSpan.FromSeconds(input);
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
 
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan));
-        }
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan));
+    }
 
-        [Theory]
-        [InlineData(1, 1, 1, 1)]
-        [InlineData(1, 1, 3, 1)]
-        [InlineData(2, 1, 3, 2)]
-        [InlineData(3, 1, 3, 3)]
-        public void ReturnsExpectedValueGivenInRangeValue(int input, int rangeFrom, int rangeTo, int expected)
-        {
-            var inputTimeSpan = TimeSpan.FromSeconds(input);
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
-            var expectedTimeSpan = TimeSpan.FromSeconds(expected);
+    [Theory]
+    [InlineData(1, 1, 1, 1)]
+    [InlineData(1, 1, 3, 1)]
+    [InlineData(2, 1, 3, 2)]
+    [InlineData(3, 1, 3, 3)]
+    public void ReturnsExpectedValueGivenInRangeValue(int input, int rangeFrom, int rangeTo, int expected)
+    {
+        var inputTimeSpan = TimeSpan.FromSeconds(input);
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+        var expectedTimeSpan = TimeSpan.FromSeconds(expected);
 
-            Assert.Equal(expectedTimeSpan, Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan));
-        }
+        Assert.Equal(expectedTimeSpan, Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan));
+    }
 
-        [Theory]
-        [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
-        {
-            var inputTimeSpan = TimeSpan.FromSeconds(-1);
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(3);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(1);
+    [Theory]
+    [InlineData(null, "rangeFrom should be less or equal than rangeTo (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenRangeIsInvalid(string customMessage, string expectedMessage)
+    {
+        var inputTimeSpan = TimeSpan.FromSeconds(-1);
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(3);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(1);
 
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, "parameterName", rangeFromTimeSpan, rangeToTimeSpan, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, "parameterName", rangeFromTimeSpan, rangeToTimeSpan, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
-        {
-            var inputTimeSpan = TimeSpan.FromSeconds(-1);
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(3);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(1);
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedRangeIsInvalid(string expectedParamName, string customMessage)
+    {
+        var inputTimeSpan = TimeSpan.FromSeconds(-1);
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(3);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(1);
 
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, expectedParamName, rangeFromTimeSpan, rangeToTimeSpan, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, expectedParamName, rangeFromTimeSpan, rangeToTimeSpan, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
 
-        [Theory]
-        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
-        {
-            var inputTimeSpan = TimeSpan.FromSeconds(-1);
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(0);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(1);
+    [Theory]
+    [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
+    [InlineData("Timespan range", "Timespan range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpectedWhenInputIsInvalid(string customMessage, string expectedMessage)
+    {
+        var inputTimeSpan = TimeSpan.FromSeconds(-1);
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(0);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(1);
 
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(inputTimeSpan, "parameterName", rangeFromTimeSpan, rangeToTimeSpan, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(inputTimeSpan, "parameterName", rangeFromTimeSpan, rangeToTimeSpan, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
-        {
-            var inputTimeSpan = TimeSpan.FromSeconds(-1);
-            var rangeFromTimeSpan = TimeSpan.FromSeconds(0);
-            var rangeToTimeSpan = TimeSpan.FromSeconds(1);
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpectedInputIsInvalid(string expectedParamName, string customMessage)
+    {
+        var inputTimeSpan = TimeSpan.FromSeconds(-1);
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(0);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(1);
 
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(inputTimeSpan, expectedParamName, rangeFromTimeSpan, rangeToTimeSpan, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(inputTimeSpan, expectedParamName, rangeFromTimeSpan, rangeToTimeSpan, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForUint.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForUint.cs
@@ -2,68 +2,67 @@
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfRangeForUint
 {
-    public class GuardAgainstOutOfRangeForUint
+    [Theory]
+    [InlineData(1, 1, 1)]
+    [InlineData(1, 1, 3)]
+    [InlineData(2, 1, 3)]
+    [InlineData(3, 1, 3)]
+    public void DoesNothingGivenInRangeValue(uint input, uint rangeFrom, uint rangeTo)
     {
-        [Theory]
-        [InlineData(1, 1, 1)]
-        [InlineData(1, 1, 3)]
-        [InlineData(2, 1, 3)]
-        [InlineData(3, 1, 3)]
-        public void DoesNothingGivenInRangeValue(uint input, uint rangeFrom, uint rangeTo)
-        {
-            Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
-        }
+        Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
+    }
 
-        [Theory]
-        [InlineData(0, 1, 3)]
-        [InlineData(4, 1, 3)]
-        public void ThrowsGivenOutOfRangeValue(uint input, uint rangeFrom, uint rangeTo)
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(0, 1, 3)]
+    [InlineData(4, 1, 3)]
+    public void ThrowsGivenOutOfRangeValue(uint input, uint rangeFrom, uint rangeTo)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(0, 3, 1)]
-        [InlineData(1, 3, 1)]
-        [InlineData(4, 3, 1)]
-        public void ThrowsGivenInvalidArgumentValue(uint input, uint rangeFrom, uint rangeTo)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(0, 3, 1)]
+    [InlineData(1, 3, 1)]
+    [InlineData(4, 3, 1)]
+    public void ThrowsGivenInvalidArgumentValue(uint input, uint rangeFrom, uint rangeTo)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(1, 1, 1, 1)]
-        [InlineData(1, 1, 3, 1)]
-        [InlineData(2, 1, 3, 2)]
-        [InlineData(3, 1, 3, 3)]
-        public void ReturnsExpectedValueGivenInRangeValue(uint input, uint rangeFrom, uint rangeTo, uint expected)
-        {
-            Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
-        }
+    [Theory]
+    [InlineData(1, 1, 1, 1)]
+    [InlineData(1, 1, 3, 1)]
+    [InlineData(2, 1, 3, 2)]
+    [InlineData(3, 1, 3, 3)]
+    public void ReturnsExpectedValueGivenInRangeValue(uint input, uint rangeFrom, uint rangeTo, uint expected)
+    {
+        Assert.Equal(expected, Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
 
-        [Theory]
-        [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
-        [InlineData("Uint range", "Uint range (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((uint)3.0d, "parameterName", (uint)0.0d, (uint)1.0d, customMessage));
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+    [Theory]
+    [InlineData(null, "Input parameterName was out of range (Parameter 'parameterName')")]
+    [InlineData("Uint range", "Uint range (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((uint)3.0d, "parameterName", (uint)0.0d, (uint)1.0d, customMessage));
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((uint)3.0d, expectedParamName, (uint)0.0d, (uint)1.0d, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange((uint)3.0d, expectedParamName, (uint)0.0d, (uint)1.0d, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
@@ -4,121 +4,120 @@ using System.Data.SqlTypes;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstOutOfSQLDateRange
 {
-    public class GuardAgainstOutOfSQLDateRange
+    [Theory]
+    [InlineData(1)]
+    [InlineData(60)]
+    [InlineData(60 * 60)]
+    [InlineData(60 * 60 * 24)]
+    [InlineData(60 * 60 * 24 * 30)]
+    [InlineData(60 * 60 * 24 * 30 * 365)]
+    public void ThrowsGivenValueBelowMinDate(int offsetInSeconds)
     {
-        [Theory]
-        [InlineData(1)]
-        [InlineData(60)]
-        [InlineData(60 * 60)]
-        [InlineData(60 * 60 * 24)]
-        [InlineData(60 * 60 * 24 * 30)]
-        [InlineData(60 * 60 * 24 * 30 * 365)]
-        public void ThrowsGivenValueBelowMinDate(int offsetInSeconds)
-        {
-            DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-offsetInSeconds);
+        DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-offsetInSeconds);
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, nameof(date)));
-        }
+        Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, nameof(date)));
+    }
 
-        [Fact]
-        public void DoNothingGivenCurrentDate()
-        {
-            Guard.Against.OutOfSQLDateRange(DateTime.Today, "Today");
-            Guard.Against.OutOfSQLDateRange(DateTime.Now, "Now");
-            Guard.Against.OutOfSQLDateRange(DateTime.UtcNow, "UTC Now");
-        }
+    [Fact]
+    public void DoNothingGivenCurrentDate()
+    {
+        Guard.Against.OutOfSQLDateRange(DateTime.Today, "Today");
+        Guard.Against.OutOfSQLDateRange(DateTime.Now, "Now");
+        Guard.Against.OutOfSQLDateRange(DateTime.UtcNow, "UTC Now");
+    }
 
-        [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(60)]
-        [InlineData(60 * 60)]
-        [InlineData(60 * 60 * 24)]
-        [InlineData(60 * 60 * 24 * 30)]
-        [InlineData(60 * 60 * 24 * 30 * 365)]
-        public void DoNothingGivenSqlMinValue(int offsetInSeconds)
-        {
-            DateTime date = SqlDateTime.MinValue.Value.AddSeconds(offsetInSeconds);
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(60)]
+    [InlineData(60 * 60)]
+    [InlineData(60 * 60 * 24)]
+    [InlineData(60 * 60 * 24 * 30)]
+    [InlineData(60 * 60 * 24 * 30 * 365)]
+    public void DoNothingGivenSqlMinValue(int offsetInSeconds)
+    {
+        DateTime date = SqlDateTime.MinValue.Value.AddSeconds(offsetInSeconds);
 
-            Guard.Against.OutOfSQLDateRange(date, nameof(date));
-        }
+        Guard.Against.OutOfSQLDateRange(date, nameof(date));
+    }
 
-        [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(60)]
-        [InlineData(60 * 60)]
-        [InlineData(60 * 60 * 24)]
-        [InlineData(60 * 60 * 24 * 30)]
-        [InlineData(60 * 60 * 24 * 30 * 365)]
-        public void DoNothingGivenSqlMaxValue(int offsetInSeconds)
-        {
-            DateTime date = SqlDateTime.MaxValue.Value.AddSeconds(-offsetInSeconds);
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(60)]
+    [InlineData(60 * 60)]
+    [InlineData(60 * 60 * 24)]
+    [InlineData(60 * 60 * 24 * 30)]
+    [InlineData(60 * 60 * 24 * 30 * 365)]
+    public void DoNothingGivenSqlMaxValue(int offsetInSeconds)
+    {
+        DateTime date = SqlDateTime.MaxValue.Value.AddSeconds(-offsetInSeconds);
 
-            Guard.Against.OutOfSQLDateRange(date, nameof(date));
-        }
+        Guard.Against.OutOfSQLDateRange(date, nameof(date));
+    }
 
-        [Theory]
-        [MemberData(nameof(GetSqlDateTimeTestVectors))]
-        public void ReturnsExpectedValueWhenGivenValidSqlDateTime(DateTime input, string name, DateTime expected)
-        {
-            Assert.Equal(expected, Guard.Against.OutOfSQLDateRange(input, name));
-        }
+    [Theory]
+    [MemberData(nameof(GetSqlDateTimeTestVectors))]
+    public void ReturnsExpectedValueWhenGivenValidSqlDateTime(DateTime input, string name, DateTime expected)
+    {
+        Assert.Equal(expected, Guard.Against.OutOfSQLDateRange(input, name));
+    }
 
-        [Theory]
-        [InlineData(null, "Input date was out of range (Parameter 'date')")]
-        [InlineData("SQLDate range", "SQLDate range (Parameter 'date')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-1);
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, nameof(date), customMessage));
+    [Theory]
+    [InlineData(null, "Input date was out of range (Parameter 'date')")]
+    [InlineData("SQLDate range", "SQLDate range (Parameter 'date')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-1);
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, nameof(date), customMessage));
 
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, "Input date was out of range (Parameter 'date')")]
-        [InlineData("SQLDate range", "SQLDate range (Parameter 'date')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided(string customMessage, string expectedMessage)
-        {
-            DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-1);
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, message: customMessage));
+    [Theory]
+    [InlineData(null, "Input date was out of range (Parameter 'date')")]
+    [InlineData("SQLDate range", "SQLDate range (Parameter 'date')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvided(string customMessage, string expectedMessage)
+    {
+        DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-1);
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, message: customMessage));
 
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-1);
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, expectedParamName, customMessage));
-            Assert.NotNull(exception);
-            Assert.Equal(expectedParamName, exception.ParamName);
-        }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-1);
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, expectedParamName, customMessage));
+        Assert.NotNull(exception);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
 
-        public static IEnumerable<object[]> GetSqlDateTimeTestVectors()
-        {
-            var now = DateTime.Now;
-            var utc = DateTime.UtcNow;
-            var yesterday = DateTime.Now.AddDays(-1);
-            var min = SqlDateTime.MinValue.Value;
-            var max = SqlDateTime.MaxValue.Value;
+    public static IEnumerable<object[]> GetSqlDateTimeTestVectors()
+    {
+        var now = DateTime.Now;
+        var utc = DateTime.UtcNow;
+        var yesterday = DateTime.Now.AddDays(-1);
+        var min = SqlDateTime.MinValue.Value;
+        var max = SqlDateTime.MaxValue.Value;
 
-            yield return new object[] { now, "now", now };
-            yield return new object[] { utc, "utc", utc };
-            yield return new object[] { yesterday, "yesterday", yesterday };
-            yield return new object[] { min, "min", min };
-            yield return new object[] { max, "max", max };
-        }
+        yield return new object[] { now, "now", now };
+        yield return new object[] { utc, "utc", utc };
+        yield return new object[] { yesterday, "yesterday", yesterday };
+        yield return new object[] { min, "min", min };
+        yield return new object[] { max, "max", max };
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstZero.cs
@@ -3,224 +3,223 @@ using System.Collections.Generic;
 using Ardalis.GuardClauses;
 using Xunit;
 
-namespace GuardClauses.UnitTests
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstZero
 {
-    public class GuardAgainstZero
+    [Fact]
+    public void DoesNothingGivenNonZeroValue()
     {
-        [Fact]
-        public void DoesNothingGivenNonZeroValue()
+        Guard.Against.Zero(-1, "minusOne");
+        Guard.Against.Zero(1, "plusOne");
+        Guard.Against.Zero(int.MinValue, "int.MinValue");
+        Guard.Against.Zero(int.MaxValue, "int.MaxValue");
+        Guard.Against.Zero(long.MinValue, "long.MinValue");
+        Guard.Against.Zero(long.MaxValue, "long.MaxValue");
+        Guard.Against.Zero(decimal.MinValue, "decimal.MinValue");
+        Guard.Against.Zero(decimal.MaxValue, "decimal.MaxValue");
+        Guard.Against.Zero(float.MinValue, "float.MinValue");
+        Guard.Against.Zero(float.MaxValue, "float.MaxValue");
+        Guard.Against.Zero(double.MinValue, "double.MinValue");
+        Guard.Against.Zero(double.MaxValue, "double.MaxValue");
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroValueIntZero()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0, "zero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroValueLongZero()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0L, "zero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroValueDecimalZero()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0M, "zero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroValueFloatZero()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0f, "zero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroValueDoubleZero()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0, "zero"));
+    }
+
+
+
+    [Fact]
+    public void ThrowsGivenZeroValueDefaultInt()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(int), "zero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroValueDefaultLong()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(long), "zero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroValueDefaultDecimal()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(decimal), "zero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroValueDefaultFloat()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(float), "zero"));
+    }
+
+    [Fact]
+    public void ThrowsGivenZeroValueDefaultDouble()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(double), "zero"));
+    }
+
+
+    [Fact]
+    public void ThrowsGivenZeroValueDecimalDotZero()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.Zero(decimal.Zero, "zero"));
+    }
+
+    [Fact]
+    public void ReturnsExpectedValueWhenGivenNonZeroValue()
+    {
+        Assert.Equal(-1, Guard.Against.Zero(-1, "minusOne"));
+        Assert.Equal(1, Guard.Against.Zero(1, "plusOne"));
+        Assert.Equal(int.MinValue, Guard.Against.Zero(int.MinValue, "int.MinValue"));
+        Assert.Equal(int.MaxValue, Guard.Against.Zero(int.MaxValue, "int.MaxValue"));
+        Assert.Equal(long.MinValue, Guard.Against.Zero(long.MinValue, "long.MinValue"));
+        Assert.Equal(long.MaxValue, Guard.Against.Zero(long.MaxValue, "long.MaxValue"));
+        Assert.Equal(decimal.MinValue, Guard.Against.Zero(decimal.MinValue, "decimal.MinValue"));
+        Assert.Equal(decimal.MaxValue, Guard.Against.Zero(decimal.MaxValue, "decimal.MaxValue"));
+        Assert.Equal(float.MinValue, Guard.Against.Zero(float.MinValue, "float.MinValue"));
+        Assert.Equal(float.MaxValue, Guard.Against.Zero(float.MaxValue, "float.MaxValue"));
+        Assert.Equal(double.MinValue, Guard.Against.Zero(double.MinValue, "double.MinValue"));
+        Assert.Equal(double.MaxValue, Guard.Against.Zero(double.MaxValue, "double.MaxValue"));
+    }
+
+    [Theory]
+    [InlineData(null, "Required input parameterName cannot be zero. (Parameter 'parameterName')")]
+    [InlineData("Value is ZERO", "Value is ZERO (Parameter 'parameterName')")]
+    public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
+    {
+        var clausesToEvaluate = new List<Action>
         {
-            Guard.Against.Zero(-1, "minusOne");
-            Guard.Against.Zero(1, "plusOne");
-            Guard.Against.Zero(int.MinValue, "int.MinValue");
-            Guard.Against.Zero(int.MaxValue, "int.MaxValue");
-            Guard.Against.Zero(long.MinValue, "long.MinValue");
-            Guard.Against.Zero(long.MaxValue, "long.MaxValue");
-            Guard.Against.Zero(decimal.MinValue, "decimal.MinValue");
-            Guard.Against.Zero(decimal.MaxValue, "decimal.MaxValue");
-            Guard.Against.Zero(float.MinValue, "float.MinValue");
-            Guard.Against.Zero(float.MaxValue, "float.MaxValue");
-            Guard.Against.Zero(double.MinValue, "double.MinValue");
-            Guard.Against.Zero(double.MaxValue, "double.MaxValue");
-        }
+            () => Guard.Against.Zero(0, "parameterName", customMessage),
+            () => Guard.Against.Zero(0L, "parameterName", customMessage),
+            () => Guard.Against.Zero(0.0M, "parameterName", customMessage),
+            () => Guard.Against.Zero(0.0f, "parameterName", customMessage),
+            () => Guard.Against.Zero(0.0, "parameterName", customMessage)
+        };
 
-        [Fact]
-        public void ThrowsGivenZeroValueIntZero()
+        foreach (var clauseToEvaluate in clausesToEvaluate)
         {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0, "zero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroValueLongZero()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0L, "zero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroValueDecimalZero()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0M, "zero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroValueFloatZero()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0f, "zero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroValueDoubleZero()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0, "zero"));
-        }
-
-
-
-        [Fact]
-        public void ThrowsGivenZeroValueDefaultInt()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(int), "zero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroValueDefaultLong()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(long), "zero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroValueDefaultDecimal()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(decimal), "zero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroValueDefaultFloat()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(float), "zero"));
-        }
-
-        [Fact]
-        public void ThrowsGivenZeroValueDefaultDouble()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(double), "zero"));
-        }
-
-
-        [Fact]
-        public void ThrowsGivenZeroValueDecimalDotZero()
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.Zero(decimal.Zero, "zero"));
-        }
-
-        [Fact]
-        public void ReturnsExpectedValueWhenGivenNonZeroValue()
-        {
-            Assert.Equal(-1, Guard.Against.Zero(-1, "minusOne"));
-            Assert.Equal(1, Guard.Against.Zero(1, "plusOne"));
-            Assert.Equal(int.MinValue, Guard.Against.Zero(int.MinValue, "int.MinValue"));
-            Assert.Equal(int.MaxValue, Guard.Against.Zero(int.MaxValue, "int.MaxValue"));
-            Assert.Equal(long.MinValue, Guard.Against.Zero(long.MinValue, "long.MinValue"));
-            Assert.Equal(long.MaxValue, Guard.Against.Zero(long.MaxValue, "long.MaxValue"));
-            Assert.Equal(decimal.MinValue, Guard.Against.Zero(decimal.MinValue, "decimal.MinValue"));
-            Assert.Equal(decimal.MaxValue, Guard.Against.Zero(decimal.MaxValue, "decimal.MaxValue"));
-            Assert.Equal(float.MinValue, Guard.Against.Zero(float.MinValue, "float.MinValue"));
-            Assert.Equal(float.MaxValue, Guard.Against.Zero(float.MaxValue, "float.MaxValue"));
-            Assert.Equal(double.MinValue, Guard.Against.Zero(double.MinValue, "double.MinValue"));
-            Assert.Equal(double.MaxValue, Guard.Against.Zero(double.MaxValue, "double.MaxValue"));
-        }
-
-        [Theory]
-        [InlineData(null, "Required input parameterName cannot be zero. (Parameter 'parameterName')")]
-        [InlineData("Value is ZERO", "Value is ZERO (Parameter 'parameterName')")]
-        public void ErrorMessageMatchesExpected(string customMessage, string expectedMessage)
-        {
-            var clausesToEvaluate = new List<Action>
-            {
-                () => Guard.Against.Zero(0, "parameterName", customMessage),
-                () => Guard.Against.Zero(0L, "parameterName", customMessage),
-                () => Guard.Against.Zero(0.0M, "parameterName", customMessage),
-                () => Guard.Against.Zero(0.0f, "parameterName", customMessage),
-                () => Guard.Against.Zero(0.0, "parameterName", customMessage)
-            };
-
-            foreach (var clauseToEvaluate in clausesToEvaluate)
-            {
-                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
-
-                Assert.NotNull(exception);
-                Assert.NotNull(exception.Message);
-                Assert.Equal(expectedMessage, exception.Message);
-            }
-        }
-
-        [Theory]
-        [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
-        [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenIntValue(string customMessage, string expectedMessage)
-        {
-            var xyz = 0;
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
+            var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
 
             Assert.NotNull(exception);
             Assert.NotNull(exception.Message);
             Assert.Equal(expectedMessage, exception.Message);
         }
+    }
 
-        [Theory]
-        [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
-        [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenLongValue(string customMessage, string expectedMessage)
+    [Theory]
+    [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
+    [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenIntValue(string customMessage, string expectedMessage)
+    {
+        var xyz = 0;
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
+    [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenLongValue(string customMessage, string expectedMessage)
+    {
+        var xyz = 0L;
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
+    [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDecimalValue(string customMessage, string expectedMessage)
+    {
+        var xyz = 0.0M;
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
+    [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenFloatValue(string customMessage, string expectedMessage)
+    {
+        var xyz = 0.0f;
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
+    [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
+    public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDoubleValue(string customMessage, string expectedMessage)
+    {
+        var xyz = 0.0;
+        var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
+
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "Please provide correct value")]
+    [InlineData("SomeParameter", null)]
+    [InlineData("SomeOtherParameter", "Value must be correct")]
+    public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
+    {
+        var clausesToEvaluate = new List<Action>
         {
-            var xyz = 0L;
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
+            () => Guard.Against.Zero(0, expectedParamName, customMessage),
+            () => Guard.Against.Zero(0L, expectedParamName, customMessage),
+            () => Guard.Against.Zero(0.0M, expectedParamName, customMessage),
+            () => Guard.Against.Zero(0.0f, expectedParamName, customMessage),
+            () => Guard.Against.Zero(0.0, expectedParamName, customMessage)
+        };
 
+        foreach (var clauseToEvaluate in clausesToEvaluate)
+        {
+            var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
             Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
-        [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDecimalValue(string customMessage, string expectedMessage)
-        {
-            var xyz = 0.0M;
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
-
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
-        [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenFloatValue(string customMessage, string expectedMessage)
-        {
-            var xyz = 0.0f;
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
-
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, "Required input xyz cannot be zero. (Parameter 'xyz')")]
-        [InlineData("Value is ZERO", "Value is ZERO (Parameter 'xyz')")]
-        public void ErrorMessageMatchesExpectedWhenNameNotExplicitlyProvidedGivenDoubleValue(string customMessage, string expectedMessage)
-        {
-            var xyz = 0.0;
-            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(xyz, message: customMessage));
-
-            Assert.NotNull(exception);
-            Assert.NotNull(exception.Message);
-            Assert.Equal(expectedMessage, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, "Please provide correct value")]
-        [InlineData("SomeParameter", null)]
-        [InlineData("SomeOtherParameter", "Value must be correct")]
-        public void ExceptionParamNameMatchesExpected(string expectedParamName, string customMessage)
-        {
-            var clausesToEvaluate = new List<Action>
-            {
-                () => Guard.Against.Zero(0, expectedParamName, customMessage),
-                () => Guard.Against.Zero(0L, expectedParamName, customMessage),
-                () => Guard.Against.Zero(0.0M, expectedParamName, customMessage),
-                () => Guard.Against.Zero(0.0f, expectedParamName, customMessage),
-                () => Guard.Against.Zero(0.0, expectedParamName, customMessage)
-            };
-
-            foreach (var clauseToEvaluate in clausesToEvaluate)
-            {
-                var exception = Assert.Throws<ArgumentException>(clauseToEvaluate);
-                Assert.NotNull(exception);
-                Assert.Equal(expectedParamName, exception.ParamName);
-            }
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardClauses.UnitTests.csproj
+++ b/test/GuardClauses.UnitTests/GuardClauses.UnitTests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="altcover" Version="8.3.838" />
+        <PackageReference Include="altcover" Version="8.3.839" />
         <PackageReference Include="coverlet.msbuild" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -16,8 +16,8 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Include="ReportGenerator" Version="5.1.9" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="ReportGenerator" Version="5.1.10" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     </ItemGroup>


### PR DESCRIPTION
This PR removes the JetBrains annotations so that we don't have that extra unnecessary dependency.  I also noticed that the project has a .editorconfig setup but the solution hadn't been formatted recently using it.  So I went ahead and ran `dotnet format` using the already existing editorconfig to bring the code up to spec.  I did that in a separate commit, so if you'd prefer I undo that just let me know.

Closes #227.