### PR TITLE
Make type parameter T of the Null() method nullable and add overload for value types.

### DIFF
--- a/src/GuardClauses/GuardAgainstNullExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNullExtensions.cs
@@ -25,12 +25,12 @@ public static partial class GuardClauseExtensions
     /// <returns><paramref name="input" /> if the value is not null.</returns>
 #if NETSTANDARD || NETFRAMEWORK
     public static T Null<T>(this IGuardClause guardClause,
-        [NotNull][ValidatedNotNull] T input,
+        [NotNull][ValidatedNotNull] T? input,
         string parameterName,
         string? message = null)
 #else
     public static T Null<T>(this IGuardClause guardClause,
-        [NotNull][ValidatedNotNull]T input,
+        [NotNull][ValidatedNotNull]T? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
 #endif
@@ -220,13 +220,13 @@ public static partial class GuardClauseExtensions
     /// <exception cref="ArgumentNullException"></exception>
 #if NETSTANDARD || NETFRAMEWORK
     public static T NullOrInvalidInput<T>(this IGuardClause guardClause,
-        T input,
+        [NotNull] T? input,
         string parameterName,
         Func<T, bool> predicate,
         string? message = null)
 #else
     public static T NullOrInvalidInput<T>(this IGuardClause guardClause,
-        T input,
+        [NotNull] T? input,
         string parameterName,
         Func<T, bool> predicate,
         string? message = null)

--- a/src/GuardClauses/GuardAgainstNullExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNullExtensions.cs
@@ -49,6 +49,39 @@ public static partial class GuardClauseExtensions
 
     /// <summary>
     /// Throws an <see cref="ArgumentNullException" /> if <paramref name="input" /> is null.
+    /// </summary>
+    /// <typeparam name="T">Must be a value type.</typeparam>
+    /// <param name="guardClause"></param>
+    /// <param name="input"></param>
+    /// <param name="parameterName"></param>
+    /// <param name="message">Optional. Custom error message</param>
+    /// <returns><paramref name="input" /> if the value is not null.</returns>
+#if NETSTANDARD || NETFRAMEWORK
+    public static T Null<T>(this IGuardClause guardClause,
+        [NotNull][ValidatedNotNull] T? input,
+        string parameterName,
+        string? message = null) where T : struct
+#else
+    public static T Null<T>(this IGuardClause guardClause,
+        [NotNull][ValidatedNotNull]T? input,
+        [CallerArgumentExpression("input")] string? parameterName = null,
+        string? message = null) where T : struct
+#endif
+    {
+        if (input is null)
+        {
+            if (string.IsNullOrEmpty(message))
+            {
+                throw new ArgumentNullException(parameterName);
+            }
+            throw new ArgumentNullException(parameterName, message);
+        }
+
+        return input.Value;
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="input" /> is null.
     /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is an empty string.
     /// </summary>
     /// <param name="guardClause"></param>

--- a/test/GuardClauses.UnitTests/GuardAgainstNull.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNull.cs
@@ -39,6 +39,41 @@ public class GuardAgainstNull
         Assert.Equal(obj, Guard.Against.Null(obj, "object"));
     }
 
+    [Fact]
+    public void ReturnsNonNullableValueTypeWhenGivenNullableValueTypeIsNotNull()
+    {
+        int? @int = 4;
+        Assert.False(IsNullableType(Guard.Against.Null(@int, "int")));
+
+        double? @double = 11.11;
+        Assert.False(IsNullableType(Guard.Against.Null(@double, "@double")));
+
+        DateTime? now = DateTime.Now;
+        Assert.False(IsNullableType(Guard.Against.Null(now, "now")));
+
+        Guid? guid = Guid.Empty;
+        Assert.False(IsNullableType(Guard.Against.Null(guid, "guid")));
+        
+        static bool IsNullableType<T>(T value)
+        {
+            if (value is null)
+            { 
+                return false; 
+            }
+            Type type = typeof(T);
+            if (!type.IsValueType)
+            {
+                return true;
+            }
+            if (Nullable.GetUnderlyingType(type) != null)
+            {
+                return true;
+            }
+            return false;
+
+        }
+    }
+
     [Theory]
     [InlineData(null, "Value cannot be null. (Parameter 'parameterName')")]
     [InlineData("Please provide correct value", "Please provide correct value (Parameter 'parameterName')")]


### PR DESCRIPTION
* Solves #260 which suppresses nullable warnings.
* Adds an additional overload of `Null()` with a value type constraint on `T` (`where T : struct`) to allow assignment to non-nullable value types when passed nullable value types. For example, the following is now allowed with this overload:
```csharp
int? nullableInt = 42;
int nonNullableInt = Guard.Against.Null(nullableInt);
``` 