### PR TITLE
291 Added backwards compatibility

### DIFF
--- a/src/GuardClauses/CompilerFixes/CallerArgumentExpressionAttribute.cs
+++ b/src/GuardClauses/CompilerFixes/CallerArgumentExpressionAttribute.cs
@@ -1,0 +1,20 @@
+﻿#if NETSTANDARD2_1
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// This a special exception for backwards compatibility.
+/// Please upgrade your dependent package to the latest supported netN.N version rather than using netstandard2.1
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+internal sealed class CallerArgumentExpressionAttribute : Attribute
+{
+    public CallerArgumentExpressionAttribute(string parameterName)
+    {
+        ParameterName = parameterName;
+    }
+
+    public string ParameterName { get; }
+}
+
+#endif

--- a/src/GuardClauses/GuardAgainstNegativeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNegativeExtensions.cs
@@ -14,7 +14,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static int Negative(this IGuardClause guardClause,
         int input,
         string parameterName,
@@ -38,7 +38,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static long Negative(this IGuardClause guardClause,
         long input,
         string parameterName,
@@ -62,7 +62,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static decimal Negative(this IGuardClause guardClause,
         decimal input,
         string parameterName,
@@ -86,7 +86,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static float Negative(IGuardClause guardClause,
         float input,
         string parameterName,
@@ -110,7 +110,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static double Negative(this IGuardClause guardClause,
         double input,
         string parameterName,
@@ -134,7 +134,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static TimeSpan Negative(this IGuardClause guardClause,
         TimeSpan input,
         string parameterName,
@@ -158,7 +158,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     private static T Negative<T>(this IGuardClause guardClause,
         T input,
         string parameterName,
@@ -186,7 +186,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static int NegativeOrZero(this IGuardClause guardClause,
         int input,
         string parameterName,
@@ -209,7 +209,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static long NegativeOrZero(this IGuardClause guardClause,
         long input,
         string parameterName,
@@ -232,7 +232,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static decimal NegativeOrZero(this IGuardClause guardClause,
         decimal input,
         string parameterName,
@@ -255,7 +255,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static float NegativeOrZero(this IGuardClause guardClause,
         float input,
         string parameterName,
@@ -278,7 +278,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static double NegativeOrZero(this IGuardClause guardClause,
         double input,
         string parameterName,
@@ -301,7 +301,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static TimeSpan NegativeOrZero(this IGuardClause guardClause,
         TimeSpan input,
         string parameterName,
@@ -325,7 +325,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     private static T NegativeOrZero<T>(this IGuardClause guardClause,
         T input,
         string parameterName,

--- a/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
@@ -15,7 +15,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
     /// <exception cref="NotFoundException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static T NotFound<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] string key,
         [NotNull][ValidatedNotNull] T? input,
@@ -48,7 +48,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
     /// <exception cref="NotFoundException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static T NotFound<TKey, T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] TKey key,
         [NotNull][ValidatedNotNull] T? input,

--- a/src/GuardClauses/GuardAgainstNullExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNullExtensions.cs
@@ -23,7 +23,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static T Null<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] T? input,
         string parameterName,
@@ -56,7 +56,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static T Null<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] T? input,
         string parameterName,
@@ -91,7 +91,7 @@ public static partial class GuardClauseExtensions
     /// <returns><paramref name="input" /> if the value is not an empty string or null.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static string NullOrEmpty(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] string? input,
         string parameterName,
@@ -123,7 +123,7 @@ public static partial class GuardClauseExtensions
     /// <returns><paramref name="input" /> if the value is not an empty guid or null.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static Guid NullOrEmpty(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] Guid? input,
         string parameterName,
@@ -155,7 +155,7 @@ public static partial class GuardClauseExtensions
     /// <returns><paramref name="input" /> if the value is not an empty enumerable or null.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static IEnumerable<T> NullOrEmpty<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] IEnumerable<T>? input,
         string parameterName,
@@ -187,7 +187,7 @@ public static partial class GuardClauseExtensions
     /// <returns><paramref name="input" /> if the value is not an empty or whitespace string.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static string NullOrWhiteSpace(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] string? input,
         string parameterName,
@@ -217,7 +217,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not default for that type.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static T Default<T>(this IGuardClause guardClause,
         [AllowNull, NotNull] T input,
         string parameterName,
@@ -251,7 +251,7 @@ public static partial class GuardClauseExtensions
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="ArgumentNullException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static T NullOrInvalidInput<T>(this IGuardClause guardClause,
         [NotNull] T? input,
         string parameterName,

--- a/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
@@ -19,7 +19,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not out of range.</returns>
     /// <exception cref="InvalidEnumArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static int EnumOutOfRange<T>(this IGuardClause guardClause,
         int input,
         string parameterName,
@@ -53,7 +53,7 @@ public static partial class GuardClauseExtensions
     /// /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not out of range.</returns>
     /// <exception cref="InvalidEnumArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static T EnumOutOfRange<T>(this IGuardClause guardClause,
         T input,
         string parameterName,
@@ -123,7 +123,7 @@ public static partial class GuardClauseExtensions
     /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static DateTime NullOrOutOfSQLDateRange(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] DateTime? input,
         string parameterName,
@@ -148,7 +148,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static DateTime OutOfSQLDateRange(this IGuardClause guardClause,
         DateTime input,
         string parameterName,

--- a/src/GuardClauses/GuardAgainstZeroExtensions.cs
+++ b/src/GuardClauses/GuardAgainstZeroExtensions.cs
@@ -15,7 +15,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static int Zero(this IGuardClause guardClause,
         int input,
         string parameterName,
@@ -39,7 +39,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static long Zero(this IGuardClause guardClause,
         long input,
         string parameterName,
@@ -63,7 +63,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static decimal Zero(this IGuardClause guardClause,
         decimal input,
         string parameterName,
@@ -87,7 +87,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static float Zero(this IGuardClause guardClause,
         float input,
         string parameterName,
@@ -111,7 +111,7 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static double Zero(this IGuardClause guardClause,
         double input,
         string parameterName,
@@ -134,7 +134,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
     public static TimeSpan Zero(this IGuardClause guardClause,
         TimeSpan input,
         string parameterName)

--- a/src/GuardClauses/GuardClauses.csproj
+++ b/src/GuardClauses/GuardClauses.csproj
@@ -6,7 +6,7 @@
         <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
     </ItemGroup>
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net7.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <PackageId>Ardalis.GuardClauses</PackageId>
         <Title>Ardalis.GuardClauses</Title>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -18,18 +18,9 @@
         <RepositoryUrl>https://github.com/ardalis/guardclauses</RepositoryUrl>
         <PackageTags>guard clause clauses assert assertion</PackageTags>
         <PackageReleaseNotes>
-            * Implemented NullOrInvalidInput method by @tiagojsrios in https://github.com/ardalis/GuardClauses/pull/178
-            * Embed license in nuget package  by @jafin in https://github.com/ardalis/GuardClauses/pull/208
-            * Remove JetBrains Annotations by @Coop56 in https://github.com/ardalis/GuardClauses/pull/236
-            * Add NullOrEmpty and NullOrWhiteSpace overloads for ReadOnlySpan by @KonH in https://github.com/ardalis/GuardClauses/pull/237
-            * Created async overload for clausules that use a predicate by @danny-bos-developer in https://github.com/ardalis/GuardClauses/pull/228
-            * Working through build issues for new contributors by @sadukie in https://github.com/ardalis/GuardClauses/pull/265
-            * Make type parameter T of the Null() method nullable and add overload for value types. by @amal-stack in https://github.com/ardalis/GuardClauses/pull/261
-            * Upgrade to dotnet 7.0 by @amal-stack in https://github.com/ardalis/GuardClauses/pull/282
-            * Adds `NullOrOutOfRange` clauses, adding support for nullable classes/structs to `OutOfRange` by @rafaelsc in https://github.com/ardalis/GuardClauses/pull/143
-            * Add README file to package
+            * Added netstandard2.1 to TargetFrameworks for backwards compatibility
         </PackageReleaseNotes>
-        <Version>4.1.1</Version>
+        <Version>4.1.2</Version>
         <AssemblyName>Ardalis.GuardClauses</AssemblyName>
         <PackageIcon>icon.png</PackageIcon>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/test/GuardClauses.UnitTests/NamespaceSeparate/ExtendingGuard.cs
+++ b/test/GuardClauses.UnitTests/NamespaceSeparate/ExtendingGuard.cs
@@ -9,7 +9,7 @@ namespace Ardalis.GuardClauses;
 /// </summary>
 public static class FooGuard
 {
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
         public static void Foo(this IGuardClause guardClause, string input, string parameterName)
 #else
     public static void Foo(this IGuardClause guardClause, string input, [CallerArgumentExpression("input")] string? parameterName = null)


### PR DESCRIPTION
Fixes #291.

To test this I referenced this project directly, in a multi target project, like so:

```xml
	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
		<Reference Include="Ardalis.GuardClauses">
			<HintPath>..\..\..\GuardClauses\src\GuardClauses\bin\Release\net7.0\Ardalis.GuardClauses.dll</HintPath>
		</Reference>
	</ItemGroup>
	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
		<Reference Include="Ardalis.GuardClauses">
			<HintPath>..\..\..\GuardClauses\src\GuardClauses\bin\Release\netstandard2.1\Ardalis.GuardClauses.dll</HintPath>
		</Reference>
	</ItemGroup>
	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
		<Reference Include="Ardalis.GuardClauses">
			<HintPath>..\..\..\GuardClauses\src\GuardClauses\bin\Release\netstandard2.1\Ardalis.GuardClauses.dll</HintPath>
		</Reference>
	</ItemGroup>
	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
		<Reference Include="Ardalis.GuardClauses">
			<HintPath>..\..\..\GuardClauses\src\GuardClauses\bin\Release\netstandard2.0\Ardalis.GuardClauses.dll</HintPath>
		</Reference>
	</ItemGroup>
```

I changed one of my unit-test that validated a `Guard.Against.Null(...);` into `net6.0` and stepped into a test. It did automatically resolve the parameterName in Lang version `10`.

Feel free to validate this locally before approving.