### PR TITLE
StringToLong

### DIFF
--- a/src/GuardClauses/GuardAgainstStringLengthExtensions.cs
+++ b/src/GuardClauses/GuardAgainstStringLengthExtensions.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using Ardalis.GuardClauses;
 
 namespace GuardClauses;
+
 public static partial class GuardClauseExtensions
 {
     /// <summary>
@@ -34,6 +35,39 @@ public static partial class GuardClauseExtensions
         {
             throw new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too short. Minimum length is {minLength}.", parameterName);
         }
+        return input;
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentException" /> if string <paramref name="input"/> is too long.
+    /// </summary>
+    /// <param name="guardClause"></param>
+    /// <param name="input"></param>
+    /// <param name="maxLength"></param>
+    /// <param name="parameterName"></param>
+    /// <param name="message">Optional. Custom error message</param>
+    /// <returns><paramref name="input" /> if the value is not negative.</returns>
+    /// <exception cref="ArgumentException"></exception>
+#if NETFRAMEWORK || NETSTANDARD2_0
+    public static string StringTooLong(this IGuardClause guardClause,
+        string input,
+        int maxLength,
+        string parameterName,
+        string? message = null)
+#else
+    public static string StringTooLong(this IGuardClause guardClause,
+        string input,
+        int maxLength,
+        [CallerArgumentExpression("input")] string? parameterName = null,
+        string? message = null)
+#endif
+    {
+        Guard.Against.NegativeOrZero(maxLength, nameof(maxLength));
+        if (input.Length > maxLength)
+        {
+            throw new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too long. Maximum length is {maxLength}.", parameterName);
+        }
+        
         return input;
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstStringTooLong.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstStringTooLong.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Ardalis.GuardClauses;
+using Xunit;
+
+namespace GuardClauses.UnitTests;
+
+public class GuardAgainstStringTooLong
+{
+    [Theory]
+    [InlineData("", 3, "string")]
+    [InlineData("a", 3, "string")]
+    [InlineData("ab", 3, "string")]
+    [InlineData("abc", 3, "string")]
+    public void DoesNothingGivenNonEmptyString(string input, int maxLength, string parameterName)
+    {
+        Guard.Against.StringTooLong(input, maxLength, parameterName);
+    }
+
+    [Theory]
+    [InlineData("a", 0, "string")]
+    [InlineData("a", -1, "string")]
+    public void ThrowsGivenNonPositiveMaxLength(string input, int maxLength, string parameterName)
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.StringTooLong(input, maxLength, parameterName));
+    }
+
+    [Fact]
+    public void ThrowsGivenStringLongerThanMaxLength()
+    {
+        Assert.Throws<ArgumentException>(() => Guard.Against.StringTooLong("aaa", 2, "string"));
+    }
+
+    [Fact]
+    public void ReturnsExpectedValueWhenGivenAStringShorterThanMaxLength()
+    {
+        var actual = Guard.Against.StringTooLong("aaa", 3, "string");
+        Assert.Equal("aaa", actual);
+    }
+}


### PR DESCRIPTION
This PR includes the implementation of the _StringTooLong_ extension method on the IGuardClause interface. This method checks whether a provided string exceeds a specified maximum length. If the string is longer than the allowed maximum, the method throws an ArgumentException. Otherwise, it returns the original string.

#325 