### PR TITLE
Removed different method signatures for NETFRAMEWORK and NETSTANDARD2_0

### DIFF
--- a/src/GuardClauses/CompilerFixes/CallerArgumentExpressionAttribute.cs
+++ b/src/GuardClauses/CompilerFixes/CallerArgumentExpressionAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_1
+﻿#if NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER
 
 namespace System.Runtime.CompilerServices;
 

--- a/src/GuardClauses/GuardAgainstExpressionExtensions.cs
+++ b/src/GuardClauses/GuardAgainstExpressionExtensions.cs
@@ -23,10 +23,8 @@ public static partial class GuardClauseExtensions
         Func<T, bool> func,
         T input,
         string message,
-#if NET7_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-        [CallerArgumentExpression("input")]
-#endif
-    string? parameterName = null) where T : struct
+        [CallerArgumentExpression("input")] string? parameterName = null)
+        where T : struct
     {
         if (func(input))
         {
@@ -53,10 +51,8 @@ public static partial class GuardClauseExtensions
         Func<T, Task<bool>> func,
         T input,
         string message,
-#if NET7_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-        [CallerArgumentExpression("input")]
-#endif
-    string? parameterName = null) where T : struct
+        [CallerArgumentExpression("input")] string? parameterName = null)
+        where T : struct
     {
         if (await func(input))
         {

--- a/src/GuardClauses/GuardAgainstNegativeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNegativeExtensions.cs
@@ -14,17 +14,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static int Negative(this IGuardClause guardClause,
-        int input,
-        string parameterName,
-        string? message = null)
-#else
     public static int Negative(this IGuardClause guardClause,
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return Negative<int>(guardClause, input, parameterName, message);
     }
@@ -38,17 +31,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static long Negative(this IGuardClause guardClause,
-        long input,
-        string parameterName,
-        string? message = null)
-#else
     public static long Negative(this IGuardClause guardClause,
         long input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return Negative<long>(guardClause, input, parameterName, message);
     }
@@ -62,17 +48,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static decimal Negative(this IGuardClause guardClause,
-        decimal input,
-        string parameterName,
-        string? message = null)
-#else
     public static decimal Negative(this IGuardClause guardClause,
         decimal input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return Negative<decimal>(guardClause, input, parameterName, message);
     }
@@ -86,17 +65,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static float Negative(IGuardClause guardClause,
-        float input,
-        string parameterName,
-        string? message = null)
-#else
     public static float Negative(this IGuardClause guardClause,
         float input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return Negative<float>(guardClause, input, parameterName, message);
     }
@@ -110,17 +82,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static double Negative(this IGuardClause guardClause,
-        double input,
-        string parameterName,
-        string? message = null)
-#else
     public static double Negative(this IGuardClause guardClause,
         double input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return Negative<double>(guardClause, input, parameterName, message);
     }
@@ -134,17 +99,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static TimeSpan Negative(this IGuardClause guardClause,
-        TimeSpan input,
-        string parameterName,
-        string? message = null)
-#else
     public static TimeSpan Negative(this IGuardClause guardClause,
         TimeSpan input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return Negative<TimeSpan>(guardClause, input, parameterName, message);
     }
@@ -158,17 +116,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    private static T Negative<T>(this IGuardClause guardClause,
-        T input,
-        string parameterName,
-        string? message = null) where T : struct, IComparable
-#else
     private static T Negative<T>(this IGuardClause guardClause,
         T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null) where T : struct, IComparable
-#endif
     {
         if (input.CompareTo(default(T)) < 0)
         {
@@ -186,17 +137,10 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static int NegativeOrZero(this IGuardClause guardClause,
-        int input,
-        string parameterName,
-        string? message = null)
-#else
     public static int NegativeOrZero(this IGuardClause guardClause,
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return NegativeOrZero<int>(guardClause, input, parameterName, message);
     }
@@ -209,17 +153,10 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static long NegativeOrZero(this IGuardClause guardClause,
-        long input,
-        string parameterName,
-        string? message = null)
-#else
     public static long NegativeOrZero(this IGuardClause guardClause,
         long input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return NegativeOrZero<long>(guardClause, input, parameterName, message);
     }
@@ -232,17 +169,10 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static decimal NegativeOrZero(this IGuardClause guardClause,
-        decimal input,
-        string parameterName,
-        string? message = null)
-#else
     public static decimal NegativeOrZero(this IGuardClause guardClause,
         decimal input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return NegativeOrZero<decimal>(guardClause, input, parameterName, message);
     }
@@ -255,17 +185,10 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static float NegativeOrZero(this IGuardClause guardClause,
-        float input,
-        string parameterName,
-        string? message = null)
-#else
     public static float NegativeOrZero(this IGuardClause guardClause,
         float input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return NegativeOrZero<float>(guardClause, input, parameterName, message);
     }
@@ -278,17 +201,10 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static double NegativeOrZero(this IGuardClause guardClause,
-        double input,
-        string parameterName,
-        string? message = null)
-#else
     public static double NegativeOrZero(this IGuardClause guardClause,
         double input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return NegativeOrZero<double>(guardClause, input, parameterName, message);
     }
@@ -301,17 +217,10 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static TimeSpan NegativeOrZero(this IGuardClause guardClause,
-        TimeSpan input,
-        string parameterName,
-        string? message = null)
-#else
     public static TimeSpan NegativeOrZero(this IGuardClause guardClause,
         TimeSpan input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return NegativeOrZero<TimeSpan>(guardClause, input, parameterName, message);
     }
@@ -325,17 +234,10 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    private static T NegativeOrZero<T>(this IGuardClause guardClause,
-        T input,
-        string parameterName,
-        string? message = null) where T : struct, IComparable
-#else
     private static T NegativeOrZero<T>(this IGuardClause guardClause,
         T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null) where T : struct, IComparable
-#endif
     {
         if (input.CompareTo(default(T)) <= 0)
         {

--- a/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
@@ -15,17 +15,10 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
     /// <exception cref="NotFoundException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static T NotFound<T>(this IGuardClause guardClause,
-        [NotNull][ValidatedNotNull] string key,
-        [NotNull][ValidatedNotNull] T? input,
-        string parameterName)
-#else
     public static T NotFound<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] string key,
         [NotNull][ValidatedNotNull] T? input,
         [CallerArgumentExpression("input")] string? parameterName = null)
-#endif
     {
         guardClause.NullOrEmpty(key, nameof(key));
 
@@ -48,17 +41,10 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
     /// <exception cref="NotFoundException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static T NotFound<TKey, T>(this IGuardClause guardClause,
-        [NotNull][ValidatedNotNull] TKey key,
-        [NotNull][ValidatedNotNull] T? input,
-        string parameterName) where TKey : struct
-#else
     public static T NotFound<TKey, T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] TKey key,
         [NotNull][ValidatedNotNull]T? input,
         [CallerArgumentExpression("input")] string? parameterName = null) where TKey : struct
-#endif
     {
         guardClause.Null(key, nameof(key));
 

--- a/src/GuardClauses/GuardAgainstNullExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNullExtensions.cs
@@ -23,17 +23,10 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static T Null<T>(this IGuardClause guardClause,
-        [NotNull][ValidatedNotNull] T? input,
-        string parameterName,
-        string? message = null)
-#else
     public static T Null<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull]T? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         if (input is null)
         {
@@ -56,17 +49,10 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static T Null<T>(this IGuardClause guardClause,
-        [NotNull][ValidatedNotNull] T? input,
-        string parameterName,
-        string? message = null) where T : struct
-#else
     public static T Null<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull]T? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null) where T : struct
-#endif
     {
         if (input is null)
         {
@@ -91,17 +77,10 @@ public static partial class GuardClauseExtensions
     /// <returns><paramref name="input" /> if the value is not an empty string or null.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static string NullOrEmpty(this IGuardClause guardClause,
-        [NotNull][ValidatedNotNull] string? input,
-        string parameterName,
-        string? message = null)
-#else
     public static string NullOrEmpty(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] string? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         Guard.Against.Null(input, parameterName, message);
         if (input == string.Empty)
@@ -123,17 +102,10 @@ public static partial class GuardClauseExtensions
     /// <returns><paramref name="input" /> if the value is not an empty guid or null.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static Guid NullOrEmpty(this IGuardClause guardClause,
-        [NotNull][ValidatedNotNull] Guid? input,
-        string parameterName,
-        string? message = null)
-#else
     public static Guid NullOrEmpty(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] Guid? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         Guard.Against.Null(input, parameterName, message);
         if (input == Guid.Empty)
@@ -155,17 +127,10 @@ public static partial class GuardClauseExtensions
     /// <returns><paramref name="input" /> if the value is not an empty enumerable or null.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static IEnumerable<T> NullOrEmpty<T>(this IGuardClause guardClause,
-        [NotNull][ValidatedNotNull] IEnumerable<T>? input,
-        string parameterName,
-        string? message = null)
-#else
     public static IEnumerable<T> NullOrEmpty<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] IEnumerable<T>? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         Guard.Against.Null(input, parameterName, message);
         
@@ -192,17 +157,10 @@ public static partial class GuardClauseExtensions
     /// <returns><paramref name="input" /> if the value is not an empty or whitespace string.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static string NullOrWhiteSpace(this IGuardClause guardClause,
-        [NotNull][ValidatedNotNull] string? input,
-        string parameterName,
-        string? message = null)
-#else
     public static string NullOrWhiteSpace(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] string? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         Guard.Against.NullOrEmpty(input, parameterName, message);
         if (String.IsNullOrWhiteSpace(input))
@@ -222,17 +180,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not default for that type.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static T Default<T>(this IGuardClause guardClause,
-        [AllowNull, NotNull] T input,
-        string parameterName,
-        string? message = null)
-#else
     public static T Default<T>(this IGuardClause guardClause,
         [AllowNull, NotNull]T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         if (EqualityComparer<T>.Default.Equals(input, default(T)!) || input is null)
         {
@@ -256,19 +207,11 @@ public static partial class GuardClauseExtensions
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="ArgumentNullException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
     public static T NullOrInvalidInput<T>(this IGuardClause guardClause,
         [NotNull] T? input,
         string parameterName,
         Func<T, bool> predicate,
         string? message = null)
-#else
-    public static T NullOrInvalidInput<T>(this IGuardClause guardClause,
-        [NotNull] T? input,
-        string parameterName,
-        Func<T, bool> predicate,
-        string? message = null)
-#endif
     {
         Guard.Against.Null(input, parameterName, message);
 

--- a/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
@@ -21,21 +21,12 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static string LengthOutOfRange(this IGuardClause guardClause,
-        string input,
-        int minLength,
-        int maxLength,
-        string parameterName,
-        string? message = null)
-#else
     public static string LengthOutOfRange(this IGuardClause guardClause,
         string input,
         int minLength,
         int maxLength,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         Guard.Against.Negative<int>(maxLength - minLength, parameterName: "min or max length",
             message: "Min length must be equal or less than max length.");
@@ -55,17 +46,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not out of range.</returns>
     /// <exception cref="InvalidEnumArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static int EnumOutOfRange<T>(this IGuardClause guardClause,
-        int input,
-        string parameterName,
-        string? message = null) where T : struct, Enum
-#else
     public static int EnumOutOfRange<T>(this IGuardClause guardClause,
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null) where T : struct, Enum
-#endif
     {
         if (!Enum.IsDefined(typeof(T), input))
         {
@@ -89,17 +73,10 @@ public static partial class GuardClauseExtensions
     /// /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not out of range.</returns>
     /// <exception cref="InvalidEnumArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static T EnumOutOfRange<T>(this IGuardClause guardClause,
-        T input,
-        string parameterName,
-        string? message = null) where T : struct, Enum
-#else
     public static T EnumOutOfRange<T>(this IGuardClause guardClause,
         T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null) where T : struct, Enum
-#endif
     {
         if (!Enum.IsDefined(typeof(T), input))
         {
@@ -159,17 +136,10 @@ public static partial class GuardClauseExtensions
     /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static DateTime NullOrOutOfSQLDateRange(this IGuardClause guardClause,
-        [NotNull][ValidatedNotNull] DateTime? input,
-        string parameterName,
-        string? message = null)
-#else
     public static DateTime NullOrOutOfSQLDateRange(this IGuardClause guardClause,
          [NotNull][ValidatedNotNull] DateTime? input,
          [CallerArgumentExpression("input")] string? parameterName = null,
          string? message = null)
-#endif
     {
         guardClause.Null(input, nameof(input));
         return OutOfSQLDateRange(guardClause, input.Value, parameterName, message);
@@ -184,17 +154,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static DateTime OutOfSQLDateRange(this IGuardClause guardClause,
-        DateTime input,
-        string parameterName,
-        string? message = null)
-#else
     public static DateTime OutOfSQLDateRange(this IGuardClause guardClause,
         DateTime input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         // System.Data is unavailable in .NET Standard so we can't use SqlDateTime.
         const long sqlMinDateTicks = 552877920000000000;

--- a/src/GuardClauses/GuardAgainstStringLengthExtensions.cs
+++ b/src/GuardClauses/GuardAgainstStringLengthExtensions.cs
@@ -20,19 +20,11 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static string StringTooShort(this IGuardClause guardClause,
-        string input,
-        int minLength,
-        string parameterName,
-        string? message = null)
-#else
     public static string StringTooShort(this IGuardClause guardClause,
         string input,
         int minLength,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         Guard.Against.NegativeOrZero(minLength, nameof(minLength));
         if (input.Length < minLength)
@@ -52,19 +44,11 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static string StringTooLong(this IGuardClause guardClause,
-        string input,
-        int maxLength,
-        string parameterName,
-        string? message = null)
-#else
     public static string StringTooLong(this IGuardClause guardClause,
         string input,
         int maxLength,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         Guard.Against.NegativeOrZero(maxLength, nameof(maxLength));
         if (input.Length > maxLength)

--- a/src/GuardClauses/GuardAgainstZeroExtensions.cs
+++ b/src/GuardClauses/GuardAgainstZeroExtensions.cs
@@ -15,17 +15,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static int Zero(this IGuardClause guardClause,
-        int input,
-        string parameterName,
-        string? message = null)
-#else
     public static int Zero(this IGuardClause guardClause,
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return Zero<int>(guardClause, input, parameterName!, message);
     }
@@ -39,17 +32,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static long Zero(this IGuardClause guardClause,
-        long input,
-        string parameterName,
-        string? message = null)
-#else
     public static long Zero(this IGuardClause guardClause,
         long input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return Zero<long>(guardClause, input, parameterName!, message);
     }
@@ -63,17 +49,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static decimal Zero(this IGuardClause guardClause,
-        decimal input,
-        string parameterName,
-        string? message = null)
-#else
     public static decimal Zero(this IGuardClause guardClause,
         decimal input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return Zero<decimal>(guardClause, input, parameterName!, message);
     }
@@ -87,17 +66,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static float Zero(this IGuardClause guardClause,
-        float input,
-        string parameterName,
-        string? message = null)
-#else
     public static float Zero(this IGuardClause guardClause,
         float input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return Zero<float>(guardClause, input, parameterName!, message);
     }
@@ -111,17 +83,10 @@ public static partial class GuardClauseExtensions
     /// <param name="message">Optional. Custom error message</param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static double Zero(this IGuardClause guardClause,
-        double input,
-        string parameterName,
-        string? message = null)
-#else
     public static double Zero(this IGuardClause guardClause,
         double input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null)
-#endif
     {
         return Zero<double>(guardClause, input, parameterName!, message);
     }
@@ -134,15 +99,9 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-#if NETFRAMEWORK || NETSTANDARD2_0
-    public static TimeSpan Zero(this IGuardClause guardClause,
-        TimeSpan input,
-        string parameterName)
-#else
     public static TimeSpan Zero(this IGuardClause guardClause,
         TimeSpan input,
         [CallerArgumentExpression("input")] string? parameterName = null)
-#endif
     {
         return Zero<TimeSpan>(guardClause, input, parameterName!);
     }


### PR DESCRIPTION
The CallerArgumentExpressionAttribute also works for older versions than NETSTANDARD2_1.

So I changed the compiler directives accordingly and removed all differing signatures.
