### PR TITLE
Added new "exception" optional parameter

### DIFF
--- a/src/GuardClauses/GuardAgainstEmptyOrWhiteSpaceExtensions.cs
+++ b/src/GuardClauses/GuardAgainstEmptyOrWhiteSpaceExtensions.cs
@@ -12,7 +12,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException">Optional. Custom exception</param>
+    /// <param name="exception">Optional. Custom exception</param>
     /// <returns><paramref name="input" /> if the value is not an empty string.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -21,11 +21,11 @@ public static partial class GuardClauseExtensions
         ReadOnlySpan<char> input,
         string parameterName,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
         if (input.Length == 0 || input == string.Empty)
         {
-            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
+            throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
         }
         return input;
     }
@@ -37,18 +37,18 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException">Optional. Custom exception</param>
+    /// <param name="exception">Optional. Custom exception</param>
     /// <returns><paramref name="input" /> if the value is not an empty or whitespace string.</returns>
     /// <exception cref="ArgumentException"></exception>
     public static ReadOnlySpan<char> WhiteSpace(this IGuardClause guardClause,
         ReadOnlySpan<char> input,
         string parameterName,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
         if (MemoryExtensions.IsWhiteSpace(input))
         {
-            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName!);
+            throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName!);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstEmptyOrWhiteSpaceExtensions.cs
+++ b/src/GuardClauses/GuardAgainstEmptyOrWhiteSpaceExtensions.cs
@@ -6,43 +6,49 @@ public static partial class GuardClauseExtensions
 {
 #if NET5_0_OR_GREATER
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is an empty string.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is an empty string.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException">Optional. Custom exception</param>
     /// <returns><paramref name="input" /> if the value is not an empty string.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
+
     public static ReadOnlySpan<char> Empty(this IGuardClause guardClause,
         ReadOnlySpan<char> input,
         string parameterName,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
         if (input.Length == 0 || input == string.Empty)
         {
-            throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
         }
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is an empty or white space string.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is an empty or white space string.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException">Optional. Custom exception</param>
     /// <returns><paramref name="input" /> if the value is not an empty or whitespace string.</returns>
     /// <exception cref="ArgumentException"></exception>
     public static ReadOnlySpan<char> WhiteSpace(this IGuardClause guardClause,
         ReadOnlySpan<char> input,
         string parameterName,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
         if (MemoryExtensions.IsWhiteSpace(input))
         {
-            throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName!);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstExpressionExtensions.cs
+++ b/src/GuardClauses/GuardAgainstExpressionExtensions.cs
@@ -7,9 +7,9 @@ namespace Ardalis.GuardClauses;
 public static partial class GuardClauseExtensions
 {
     /// <summary>
-    /// Validates the <paramref name="input"/> using the specified <paramref name="func"/> and throws an <see cref="ArgumentException"/> if it evaluates to true.
+    /// Validates the <paramref name="input"/> using the specified <paramref name="func"/> and throws an <see cref="ArgumentException"/> or a custom <see cref="Exception" /> if it evaluates to true.
     /// The <paramref name="func"/> should return true to indicate an invalid or undesirable state of the input.
-    /// If <paramref name="func"/> returns true, an <see cref="ArgumentException"/> is thrown, signifying that the input is invalid.
+    /// If <paramref name="func"/> returns true, an <see cref="ArgumentException"/> or a custom <see cref="Exception" /> is thrown, signifying that the input is invalid.
     /// </summary>
     /// <typeparam name="T">The type of the input parameter.</typeparam>
     /// <param name="guardClause">The guard clause instance.</param>
@@ -17,27 +17,30 @@ public static partial class GuardClauseExtensions
     /// <param name="input">The input to evaluate.</param>
     /// <param name="message">The message to include in the exception if the input is invalid.</param>
     /// <param name="parameterName">The name of the parameter to include in the thrown exception, captured automatically from the input expression.</param>
+    /// <param name="customException"></param>
     /// <returns>The <paramref name="input"/> if the <paramref name="func"/> evaluates to false, indicating a valid state.</returns>
     /// <exception cref="ArgumentException">Thrown when the validation function returns true, indicating that the input is invalid.</exception>
+    /// <exception cref="Exception"></exception>
     public static T Expression<T>(this IGuardClause guardClause,
         Func<T, bool> func,
         T input,
         string message,
-        [CallerArgumentExpression("input")] string? parameterName = null)
+        [CallerArgumentExpression("input")] string? parameterName = null,
+        Exception? customException = null)
         where T : struct
     {
         if (func(input))
         {
-            throw new ArgumentException(message, parameterName!);
+            throw customException ?? new ArgumentException(message, parameterName!);
         }
 
         return input;
     }
 
     /// <summary>
-    /// Validates the <paramref name="func"/> asynchronously and throws an <see cref="ArgumentException" /> if it evaluates to false for given <paramref name="input"/>
+    /// Validates the <paramref name="func"/> asynchronously and throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if it evaluates to false for given <paramref name="input"/>
     /// The <paramref name="func"/> should return true to indicate an invalid or undesirable state.
-    /// If <paramref name="func"/> returns true, indicating that the input is invalid, an <see cref="ArgumentException"/> is thrown.
+    /// If <paramref name="func"/> returns true, indicating that the input is invalid, an <see cref="ArgumentException"/> or a custom <see cref="Exception" /> is thrown.
     /// </summary>
     /// <typeparam name="T">The type of the input parameter.</typeparam>
     /// <param name="func">The function that evaluates the input. It should return true if the input is considered invalid or in a negative state.</param>
@@ -45,18 +48,21 @@ public static partial class GuardClauseExtensions
     /// <param name="input">The input to evaluate.</param>
     /// <param name="message">The message to include in the exception if the input is invalid.</param>
     /// <param name="parameterName">The name of the parameter to include in the thrown exception, captured automatically from the input expression.</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input"/> if the <paramref name="func"/> evaluates to true </returns>
     /// <exception cref="ArgumentException">Thrown when the validation function returns true, indicating that the input is invalid.</exception>
+    /// <exception cref="Exception"></exception>
     public static async Task<T> ExpressionAsync<T>(this IGuardClause guardClause,
         Func<T, Task<bool>> func,
         T input,
         string message,
-        [CallerArgumentExpression("input")] string? parameterName = null)
+        [CallerArgumentExpression("input")] string? parameterName = null,
+        Exception? customException = null)
         where T : struct
     {
         if (await func(input))
         {
-            throw new ArgumentException(message, parameterName!);
+            throw customException ?? new ArgumentException(message, parameterName!);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstExpressionExtensions.cs
+++ b/src/GuardClauses/GuardAgainstExpressionExtensions.cs
@@ -17,7 +17,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input">The input to evaluate.</param>
     /// <param name="message">The message to include in the exception if the input is invalid.</param>
     /// <param name="parameterName">The name of the parameter to include in the thrown exception, captured automatically from the input expression.</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns>The <paramref name="input"/> if the <paramref name="func"/> evaluates to false, indicating a valid state.</returns>
     /// <exception cref="ArgumentException">Thrown when the validation function returns true, indicating that the input is invalid.</exception>
     /// <exception cref="Exception"></exception>
@@ -26,12 +26,12 @@ public static partial class GuardClauseExtensions
         T input,
         string message,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        Exception? customException = null)
+        Exception? exception = null)
         where T : struct
     {
         if (func(input))
         {
-            throw customException ?? new ArgumentException(message, parameterName!);
+            throw exception ?? new ArgumentException(message, parameterName!);
         }
 
         return input;
@@ -48,7 +48,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input">The input to evaluate.</param>
     /// <param name="message">The message to include in the exception if the input is invalid.</param>
     /// <param name="parameterName">The name of the parameter to include in the thrown exception, captured automatically from the input expression.</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input"/> if the <paramref name="func"/> evaluates to true </returns>
     /// <exception cref="ArgumentException">Thrown when the validation function returns true, indicating that the input is invalid.</exception>
     /// <exception cref="Exception"></exception>
@@ -57,12 +57,12 @@ public static partial class GuardClauseExtensions
         T input,
         string message,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        Exception? customException = null)
+        Exception? exception = null)
         where T : struct
     {
         if (await func(input))
         {
-            throw customException ?? new ArgumentException(message, parameterName!);
+            throw exception ?? new ArgumentException(message, parameterName!);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstInvalidFormatExtensions.cs
+++ b/src/GuardClauses/GuardAgainstInvalidFormatExtensions.cs
@@ -7,71 +7,83 @@ namespace Ardalis.GuardClauses;
 public static partial class GuardClauseExtensions
 {
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if  <paramref name="input"/> doesn't match the <paramref name="regexPattern"/>.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if  <paramref name="input"/> doesn't match the <paramref name="regexPattern"/>.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="regexPattern"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static string InvalidFormat(this IGuardClause guardClause,
         string input,
         string parameterName,
         string regexPattern,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
         var m = Regex.Match(input, regexPattern);
         if (!m.Success || input != m.Value)
         {
-            throw new ArgumentException(message ?? $"Input {parameterName} was not in required format", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Input {parameterName} was not in required format", parameterName);
         }
 
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if  <paramref name="input"/> doesn't satisfy the <paramref name="predicate"/> function.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if  <paramref name="input"/> doesn't satisfy the <paramref name="predicate"/> function.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="predicate"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
-    public static T InvalidInput<T>(this IGuardClause guardClause, T input, string parameterName, Func<T, bool> predicate, string? message = null)
+    /// <exception cref="Exception"></exception>
+    public static T InvalidInput<T>(this IGuardClause guardClause, 
+        T input, string parameterName, 
+        Func<T, bool> predicate, 
+        string? message = null,
+        Exception? customException = null)
     {
         if (!predicate(input))
         {
-            throw new ArgumentException(message ?? $"Input {parameterName} did not satisfy the options", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Input {parameterName} did not satisfy the options", parameterName);
         }
 
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if  <paramref name="input"/> doesn't satisfy the <paramref name="predicate"/> function.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if  <paramref name="input"/> doesn't satisfy the <paramref name="predicate"/> function.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="predicate"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static async Task<T> InvalidInputAsync<T>(this IGuardClause guardClause,
         T input,
         string parameterName,
         Func<T, Task<bool>> predicate,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
         if (!await predicate(input))
         {
-            throw new ArgumentException(message ?? $"Input {parameterName} did not satisfy the options", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Input {parameterName} did not satisfy the options", parameterName);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstInvalidFormatExtensions.cs
+++ b/src/GuardClauses/GuardAgainstInvalidFormatExtensions.cs
@@ -14,7 +14,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="regexPattern"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -23,12 +23,12 @@ public static partial class GuardClauseExtensions
         string parameterName,
         string regexPattern,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
         var m = Regex.Match(input, regexPattern);
         if (!m.Success || input != m.Value)
         {
-            throw customException ?? new ArgumentException(message ?? $"Input {parameterName} was not in required format", parameterName);
+            throw exception ?? new ArgumentException(message ?? $"Input {parameterName} was not in required format", parameterName);
         }
 
         return input;
@@ -42,7 +42,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="predicate"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
@@ -51,11 +51,11 @@ public static partial class GuardClauseExtensions
         T input, string parameterName, 
         Func<T, bool> predicate, 
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
         if (!predicate(input))
         {
-            throw customException ?? new ArgumentException(message ?? $"Input {parameterName} did not satisfy the options", parameterName);
+            throw exception ?? new ArgumentException(message ?? $"Input {parameterName} did not satisfy the options", parameterName);
         }
 
         return input;
@@ -69,7 +69,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="predicate"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
@@ -79,11 +79,11 @@ public static partial class GuardClauseExtensions
         string parameterName,
         Func<T, Task<bool>> predicate,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
         if (!await predicate(input))
         {
-            throw customException ?? new ArgumentException(message ?? $"Input {parameterName} did not satisfy the options", parameterName);
+            throw exception ?? new ArgumentException(message ?? $"Input {parameterName} did not satisfy the options", parameterName);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstNegativeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNegativeExtensions.cs
@@ -12,7 +12,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -20,9 +20,9 @@ public static partial class GuardClauseExtensions
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
-        return Negative<int>(guardClause, input, parameterName, message, customException);
+        return Negative<int>(guardClause, input, parameterName, message, exception);
     }
 
     /// <summary>
@@ -32,7 +32,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -40,9 +40,9 @@ public static partial class GuardClauseExtensions
         long input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
-        return Negative<long>(guardClause, input, parameterName, message, customException);
+        return Negative<long>(guardClause, input, parameterName, message, exception);
     }
 
     /// <summary>
@@ -52,16 +52,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="Exception"></exception>
     public static decimal Negative(this IGuardClause guardClause,
         decimal input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null, 
-        Exception? customException = null)
+        Exception? exception = null)
     {
-        return Negative<decimal>(guardClause, input, parameterName, message, customException);
+        return Negative<decimal>(guardClause, input, parameterName, message, exception);
     }
 
     /// <summary>
@@ -71,15 +71,15 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="Exception"></exception>
     public static float Negative(this IGuardClause guardClause,
         float input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
-        return Negative<float>(guardClause, input, parameterName, message, customException);
+        return Negative<float>(guardClause, input, parameterName, message, exception);
     }
 
     /// <summary>
@@ -89,15 +89,15 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="Exception"></exception>
     public static double Negative(this IGuardClause guardClause,
         double input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
-        return Negative<double>(guardClause, input, parameterName, message, customException);
+        return Negative<double>(guardClause, input, parameterName, message, exception);
     }
 
     /// <summary>
@@ -107,15 +107,15 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="Exception"></exception>
     public static TimeSpan Negative(this IGuardClause guardClause,
         TimeSpan input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
-        return Negative<TimeSpan>(guardClause, input, parameterName, message, customException);
+        return Negative<TimeSpan>(guardClause, input, parameterName, message, exception);
     }
 
     /// <summary>
@@ -125,18 +125,18 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     private static T Negative<T>(this IGuardClause guardClause,
         T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null) where T : struct, IComparable
+        string? message = null, Exception? exception = null) where T : struct, IComparable
     {
         if (input.CompareTo(default(T)) < 0)
         {
-            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} cannot be negative.", parameterName!);
+            throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} cannot be negative.", parameterName!);
         }
 
         return input;
@@ -149,16 +149,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static int NegativeOrZero(this IGuardClause guardClause,
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
-        return NegativeOrZero<int>(guardClause, input, parameterName, message, customException);
+        return NegativeOrZero<int>(guardClause, input, parameterName, message, exception);
     }
 
     /// <summary>
@@ -168,16 +168,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static long NegativeOrZero(this IGuardClause guardClause,
         long input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
-        return NegativeOrZero<long>(guardClause, input, parameterName, message, customException);
+        return NegativeOrZero<long>(guardClause, input, parameterName, message, exception);
     }
 
     /// <summary>
@@ -187,16 +187,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static decimal NegativeOrZero(this IGuardClause guardClause,
         decimal input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
-        return NegativeOrZero<decimal>(guardClause, input, parameterName, message, customException);
+        return NegativeOrZero<decimal>(guardClause, input, parameterName, message, exception);
     }
 
     /// <summary>
@@ -206,16 +206,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static float NegativeOrZero(this IGuardClause guardClause,
         float input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
-        return NegativeOrZero<float>(guardClause, input, parameterName, message, customException);
+        return NegativeOrZero<float>(guardClause, input, parameterName, message, exception);
     }
 
     /// <summary>
@@ -225,16 +225,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static double NegativeOrZero(this IGuardClause guardClause,
         double input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
-        return NegativeOrZero<double>(guardClause, input, parameterName, message, customException);
+        return NegativeOrZero<double>(guardClause, input, parameterName, message, exception);
     }
 
     /// <summary>
@@ -244,16 +244,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static TimeSpan NegativeOrZero(this IGuardClause guardClause,
         TimeSpan input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
-        return NegativeOrZero<TimeSpan>(guardClause, input, parameterName, message, customException);
+        return NegativeOrZero<TimeSpan>(guardClause, input, parameterName, message, exception);
     }
 
     /// <summary>
@@ -264,7 +264,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -272,11 +272,11 @@ public static partial class GuardClauseExtensions
         T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null, 
-        Exception? customException = null) where T : struct, IComparable
+        Exception? exception = null) where T : struct, IComparable
     {
         if (input.CompareTo(default(T)) <= 0)
         {
-            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} cannot be zero or negative.", parameterName!);
+            throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} cannot be zero or negative.", parameterName!);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstNegativeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNegativeExtensions.cs
@@ -6,242 +6,277 @@ namespace Ardalis.GuardClauses;
 public static partial class GuardClauseExtensions
 {
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static int Negative(this IGuardClause guardClause,
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
-        return Negative<int>(guardClause, input, parameterName, message);
+        return Negative<int>(guardClause, input, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static long Negative(this IGuardClause guardClause,
         long input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
-        return Negative<long>(guardClause, input, parameterName, message);
+        return Negative<long>(guardClause, input, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
-    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static decimal Negative(this IGuardClause guardClause,
         decimal input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, 
+        Exception? customException = null)
     {
-        return Negative<decimal>(guardClause, input, parameterName, message);
+        return Negative<decimal>(guardClause, input, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
-    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static float Negative(this IGuardClause guardClause,
         float input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
-        return Negative<float>(guardClause, input, parameterName, message);
+        return Negative<float>(guardClause, input, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
-    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static double Negative(this IGuardClause guardClause,
         double input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
-        return Negative<double>(guardClause, input, parameterName, message);
+        return Negative<double>(guardClause, input, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
-    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static TimeSpan Negative(this IGuardClause guardClause,
         TimeSpan input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
-        return Negative<TimeSpan>(guardClause, input, parameterName, message);
+        return Negative<TimeSpan>(guardClause, input, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> is negative.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     private static T Negative<T>(this IGuardClause guardClause,
         T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null) where T : struct, IComparable
+        string? message = null, Exception? customException = null) where T : struct, IComparable
     {
         if (input.CompareTo(default(T)) < 0)
         {
-            throw new ArgumentException(message ?? $"Required input {parameterName} cannot be negative.", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} cannot be negative.", parameterName!);
         }
 
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero.
+    /// Throws an <see cref="ArgumentException"/> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative or zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static int NegativeOrZero(this IGuardClause guardClause,
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
-        return NegativeOrZero<int>(guardClause, input, parameterName, message);
+        return NegativeOrZero<int>(guardClause, input, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero.
+    /// Throws an <see cref="ArgumentException"/> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative or zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static long NegativeOrZero(this IGuardClause guardClause,
         long input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
-        return NegativeOrZero<long>(guardClause, input, parameterName, message);
+        return NegativeOrZero<long>(guardClause, input, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero.
+    /// Throws an <see cref="ArgumentException"/> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative or zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static decimal NegativeOrZero(this IGuardClause guardClause,
         decimal input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
-        return NegativeOrZero<decimal>(guardClause, input, parameterName, message);
+        return NegativeOrZero<decimal>(guardClause, input, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero.
+    /// Throws an <see cref="ArgumentException"/> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative or zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static float NegativeOrZero(this IGuardClause guardClause,
         float input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
-        return NegativeOrZero<float>(guardClause, input, parameterName, message);
+        return NegativeOrZero<float>(guardClause, input, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero.
+    /// Throws an <see cref="ArgumentException"/> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative or zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static double NegativeOrZero(this IGuardClause guardClause,
         double input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
-        return NegativeOrZero<double>(guardClause, input, parameterName, message);
+        return NegativeOrZero<double>(guardClause, input, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero.
+    /// Throws an <see cref="ArgumentException"/> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative or zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static TimeSpan NegativeOrZero(this IGuardClause guardClause,
         TimeSpan input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
-        return NegativeOrZero<TimeSpan>(guardClause, input, parameterName, message);
+        return NegativeOrZero<TimeSpan>(guardClause, input, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException"/> if <paramref name="input"/> is negative or zero. 
+    /// Throws an <see cref="ArgumentException"/> or a custom <see cref="Exception" /> if <paramref name="input"/> is negative or zero. 
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     private static T NegativeOrZero<T>(this IGuardClause guardClause,
         T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null) where T : struct, IComparable
+        string? message = null, 
+        Exception? customException = null) where T : struct, IComparable
     {
         if (input.CompareTo(default(T)) <= 0)
         {
-            throw new ArgumentException(message ?? $"Required input {parameterName} cannot be zero or negative.", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} cannot be zero or negative.", parameterName!);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
@@ -14,7 +14,7 @@ public static partial class GuardClauseExtensions
     /// <param name="key"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
     /// <exception cref="NotFoundException"></exception>
     /// <exception cref="Exception"></exception>
@@ -22,13 +22,13 @@ public static partial class GuardClauseExtensions
         [NotNull][ValidatedNotNull] string key,
         [NotNull][ValidatedNotNull] T? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
         guardClause.NullOrEmpty(key, nameof(key));
 
         if (input is null)
         {
-            throw customException ?? new NotFoundException(key, parameterName!);
+            throw exception ?? new NotFoundException(key, parameterName!);
         }
 
         return input;
@@ -43,7 +43,7 @@ public static partial class GuardClauseExtensions
     /// <param name="key"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
     /// <exception cref="NotFoundException"></exception>
     /// <exception cref="Exception"></exception>
@@ -51,14 +51,14 @@ public static partial class GuardClauseExtensions
         [NotNull][ValidatedNotNull] TKey key,
         [NotNull][ValidatedNotNull]T? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        Exception? customException = null) where TKey : struct
+        Exception? exception = null) where TKey : struct
     {
         guardClause.Null(key, nameof(key));
 
         if (input is null)
         {
             // TODO: Can we safely consider that ToString() won't return null for struct?
-            throw customException ?? new NotFoundException(key.ToString()!, parameterName!);
+            throw exception ?? new NotFoundException(key.ToString()!, parameterName!);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Ardalis.GuardClauses;
@@ -6,32 +7,35 @@ namespace Ardalis.GuardClauses;
 public static partial class GuardClauseExtensions
 {
     /// <summary>
-    /// Throws an <see cref="NotFoundException" /> if <paramref name="input" /> with <paramref name="key" /> is not found.
+    /// Throws an <see cref="NotFoundException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> with <paramref name="key" /> is not found.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="guardClause"></param>
     /// <param name="key"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
     /// <exception cref="NotFoundException"></exception>
+    /// <exception cref="Exception"></exception>
     public static T NotFound<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] string key,
         [NotNull][ValidatedNotNull] T? input,
-        [CallerArgumentExpression("input")] string? parameterName = null)
+        [CallerArgumentExpression("input")] string? parameterName = null,
+        Exception? customException = null)
     {
         guardClause.NullOrEmpty(key, nameof(key));
 
         if (input is null)
         {
-            throw new NotFoundException(key, parameterName!);
+            throw customException ?? new NotFoundException(key, parameterName!);
         }
 
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="NotFoundException" /> if <paramref name="input" /> with <paramref name="key" /> is not found.
+    /// Throws an <see cref="NotFoundException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> with <paramref name="key" /> is not found.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <typeparam name="TKey"></typeparam>
@@ -39,19 +43,22 @@ public static partial class GuardClauseExtensions
     /// <param name="key"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
     /// <exception cref="NotFoundException"></exception>
+    /// <exception cref="Exception"></exception>
     public static T NotFound<TKey, T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] TKey key,
         [NotNull][ValidatedNotNull]T? input,
-        [CallerArgumentExpression("input")] string? parameterName = null) where TKey : struct
+        [CallerArgumentExpression("input")] string? parameterName = null,
+        Exception? customException = null) where TKey : struct
     {
         guardClause.Null(key, nameof(key));
 
         if (input is null)
         {
             // TODO: Can we safely consider that ToString() won't return null for struct?
-            throw new NotFoundException(key.ToString()!, parameterName!);
+            throw customException ?? new NotFoundException(key.ToString()!, parameterName!);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstNullExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNullExtensions.cs
@@ -22,22 +22,22 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
     /// <exception cref="Exception"></exception>
     public static T Null<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull]T? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
         if (input is null)
         {
             if (string.IsNullOrEmpty(message))
             {
-                throw customException ?? new ArgumentNullException(parameterName);
+                throw exception ?? new ArgumentNullException(parameterName);
             }
-            throw customException ?? new ArgumentNullException(parameterName, message);
+            throw exception ?? new ArgumentNullException(parameterName, message);
         }
 
         return input;
@@ -51,22 +51,22 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
     /// <exception cref="Exception"></exception>
     public static T Null<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull]T? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null) where T : struct
+        Exception? exception = null) where T : struct
     {
         if (input is null)
         {
             if (string.IsNullOrEmpty(message))
             {
-                throw customException ?? new ArgumentNullException(parameterName);
+                throw exception ?? new ArgumentNullException(parameterName);
             }
-            throw customException ?? new ArgumentNullException(parameterName, message);
+            throw exception ?? new ArgumentNullException(parameterName, message);
         }
 
         return input.Value;
@@ -80,7 +80,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not an empty string or null.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
@@ -89,12 +89,12 @@ public static partial class GuardClauseExtensions
         [NotNull][ValidatedNotNull] string? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
-        Guard.Against.Null(input, parameterName, message, customException);
+        Guard.Against.Null(input, parameterName, message, exception);
         if (input == string.Empty)
         {
-            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
+            throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
         }
 
         return input;
@@ -108,7 +108,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not an empty guid or null.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
@@ -116,12 +116,12 @@ public static partial class GuardClauseExtensions
     public static Guid NullOrEmpty(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] Guid? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
-        Guard.Against.Null(input, parameterName, message, customException);
+        Guard.Against.Null(input, parameterName, message, exception);
         if (input == Guid.Empty)
         {
-            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
+            throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
         }
 
         return input.Value;
@@ -135,7 +135,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not an empty enumerable or null.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
@@ -143,9 +143,9 @@ public static partial class GuardClauseExtensions
     public static IEnumerable<T> NullOrEmpty<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] IEnumerable<T>? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
-        Guard.Against.Null(input, parameterName, message, customException);
+        Guard.Against.Null(input, parameterName, message, exception);
         
         if (input is Array and { Length: 0 } //Try checking first with pattern matching because it's faster than TryGetNonEnumeratedCount on Array
 #if NET6_0_OR_GREATER
@@ -153,7 +153,7 @@ public static partial class GuardClauseExtensions
 #endif
             || !input.Any())
         {
-            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
+            throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
         }
 
         return input;
@@ -167,7 +167,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not an empty or whitespace string.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
@@ -175,12 +175,12 @@ public static partial class GuardClauseExtensions
     public static string NullOrWhiteSpace(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] string? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
-        Guard.Against.NullOrEmpty(input, parameterName, message, customException);
+        Guard.Against.NullOrEmpty(input, parameterName, message, exception);
         if (String.IsNullOrWhiteSpace(input))
         {
-            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
+            throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
         }
 
         return input;
@@ -193,7 +193,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not default for that type.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -201,11 +201,11 @@ public static partial class GuardClauseExtensions
         [AllowNull, NotNull]T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
         if (EqualityComparer<T>.Default.Equals(input, default(T)!) || input is null)
         {
-            throw customException ?? new ArgumentException(message ?? $"Parameter [{parameterName}] is default value for type {typeof(T).Name}", parameterName);
+            throw exception ?? new ArgumentException(message ?? $"Parameter [{parameterName}] is default value for type {typeof(T).Name}", parameterName);
         }
 
         return input;
@@ -221,7 +221,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="predicate"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
@@ -232,10 +232,10 @@ public static partial class GuardClauseExtensions
         string parameterName,
         Func<T, bool> predicate,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
-        Guard.Against.Null(input, parameterName, message, customException);
+        Guard.Against.Null(input, parameterName, message, exception);
 
-        return Guard.Against.InvalidInput(input, parameterName, predicate, message, customException);
+        return Guard.Against.InvalidInput(input, parameterName, predicate, message, exception);
     }
 }

--- a/src/GuardClauses/GuardAgainstNullExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNullExtensions.cs
@@ -15,124 +15,137 @@ namespace Ardalis.GuardClauses;
 public static partial class GuardClauseExtensions
 {
     /// <summary>
-    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="input" /> is null.
+    /// Throws an <see cref="ArgumentNullException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is null.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
+    /// <exception cref="Exception"></exception>
     public static T Null<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull]T? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
         if (input is null)
         {
             if (string.IsNullOrEmpty(message))
             {
-                throw new ArgumentNullException(parameterName);
+                throw customException ?? new ArgumentNullException(parameterName);
             }
-            throw new ArgumentNullException(parameterName, message);
+            throw customException ?? new ArgumentNullException(parameterName, message);
         }
 
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="input" /> is null.
+    /// Throws an <see cref="ArgumentNullException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is null.
     /// </summary>
     /// <typeparam name="T">Must be a value type.</typeparam>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
+    /// <exception cref="Exception"></exception>
     public static T Null<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull]T? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null) where T : struct
+        string? message = null,
+        Exception? customException = null) where T : struct
     {
         if (input is null)
         {
             if (string.IsNullOrEmpty(message))
             {
-                throw new ArgumentNullException(parameterName);
+                throw customException ?? new ArgumentNullException(parameterName);
             }
-            throw new ArgumentNullException(parameterName, message);
+            throw customException ?? new ArgumentNullException(parameterName, message);
         }
 
         return input.Value;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="input" /> is null.
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is an empty string.
+    /// Throws an <see cref="ArgumentNullException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is null.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is an empty string.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not an empty string or null.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static string NullOrEmpty(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] string? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
-        Guard.Against.Null(input, parameterName, message);
+        Guard.Against.Null(input, parameterName, message, customException);
         if (input == string.Empty)
         {
-            throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
         }
 
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="input" /> is null.
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is an empty guid.
+    /// Throws an <see cref="ArgumentNullException" /> or a custom <see cref="Exception" />if <paramref name="input" /> is null.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is an empty guid.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not an empty guid or null.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static Guid NullOrEmpty(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] Guid? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
-        Guard.Against.Null(input, parameterName, message);
+        Guard.Against.Null(input, parameterName, message, customException);
         if (input == Guid.Empty)
         {
-            throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
         }
 
         return input.Value;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="input" /> is null.
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is an empty enumerable.
+    /// Throws an <see cref="ArgumentNullException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is null.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is an empty enumerable.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not an empty enumerable or null.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static IEnumerable<T> NullOrEmpty<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] IEnumerable<T>? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
-        Guard.Against.Null(input, parameterName, message);
+        Guard.Against.Null(input, parameterName, message, customException);
         
         if (input is Array and { Length: 0 } //Try checking first with pattern matching because it's faster than TryGetNonEnumeratedCount on Array
 #if NET6_0_OR_GREATER
@@ -140,54 +153,59 @@ public static partial class GuardClauseExtensions
 #endif
             || !input.Any())
         {
-            throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
         }
 
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="input" /> is null.
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is an empty or white space string.
+    /// Throws an <see cref="ArgumentNullException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is null.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is an empty or white space string.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not an empty or whitespace string.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static string NullOrWhiteSpace(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] string? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
-        Guard.Against.NullOrEmpty(input, parameterName, message);
+        Guard.Against.NullOrEmpty(input, parameterName, message, customException);
         if (String.IsNullOrWhiteSpace(input))
         {
-            throw new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
         }
 
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is default for that type.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is default for that type.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not default for that type.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static T Default<T>(this IGuardClause guardClause,
         [AllowNull, NotNull]T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
         if (EqualityComparer<T>.Default.Equals(input, default(T)!) || input is null)
         {
-            throw new ArgumentException(message ?? $"Parameter [{parameterName}] is default value for type {typeof(T).Name}", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Parameter [{parameterName}] is default value for type {typeof(T).Name}", parameterName);
         }
 
         return input;
@@ -195,26 +213,29 @@ public static partial class GuardClauseExtensions
 
 
     /// <summary>
-    /// Throws an <see cref="ArgumentNullException"/> if <paramref name="input"/> is null
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input"/> doesn't satisfy the <paramref name="predicate"/> function.
+    /// Throws an <see cref="ArgumentNullException"/> or a custom <see cref="Exception" /> if <paramref name="input"/> is null
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> doesn't satisfy the <paramref name="predicate"/> function.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="predicate"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="Exception"></exception>
     public static T NullOrInvalidInput<T>(this IGuardClause guardClause,
         [NotNull] T? input,
         string parameterName,
         Func<T, bool> predicate,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
-        Guard.Against.Null(input, parameterName, message);
+        Guard.Against.Null(input, parameterName, message, customException);
 
-        return Guard.Against.InvalidInput(input, parameterName, predicate, message);
+        return Guard.Against.InvalidInput(input, parameterName, predicate, message, customException);
     }
 }

--- a/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
@@ -31,7 +31,7 @@ public static partial class GuardClauseExtensions
         Exception? exception = null)
     {
         Guard.Against.Negative<int>(maxLength - minLength, parameterName: "min or max length",
-            message: "Min length must be equal or less than max length.");
+            message: "Min length must be equal or less than max length.", exception: exception);
         Guard.Against.StringTooShort(input, minLength, nameof(minLength), exception: exception);
         Guard.Against.StringTooLong(input, maxLength, nameof(maxLength), exception: exception);
 

--- a/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
@@ -10,7 +10,7 @@ namespace Ardalis.GuardClauses;
 public static partial class GuardClauseExtensions
 {
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if string <paramref name="input"/> length is out of range.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if string <paramref name="input"/> length is out of range.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
@@ -18,79 +18,88 @@ public static partial class GuardClauseExtensions
     /// <param name="maxLength"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static string LengthOutOfRange(this IGuardClause guardClause,
         string input,
         int minLength,
         int maxLength,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
         Guard.Against.Negative<int>(maxLength - minLength, parameterName: "min or max length",
             message: "Min length must be equal or less than max length.");
-        Guard.Against.StringTooShort(input, minLength, nameof(minLength));
-        Guard.Against.StringTooLong(input, maxLength, nameof(maxLength));
+        Guard.Against.StringTooShort(input, minLength, nameof(minLength), customException: customException);
+        Guard.Against.StringTooLong(input, maxLength, nameof(maxLength), customException: customException);
 
         return input;
     }
-    
+
     /// <summary>
-    /// Throws an <see cref="InvalidEnumArgumentException" /> if <paramref name="input"/> is not a valid enum value.
+    /// Throws an <see cref="InvalidEnumArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> is not a valid enum value.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not out of range.</returns>
     /// <exception cref="InvalidEnumArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static int EnumOutOfRange<T>(this IGuardClause guardClause,
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null) where T : struct, Enum
+        string? message = null,
+        Exception? customException = null) where T : struct, Enum
     {
         if (!Enum.IsDefined(typeof(T), input))
         {
             if (string.IsNullOrEmpty(message))
             {
-                throw new InvalidEnumArgumentException(parameterName, input, typeof(T));
+                throw customException ?? new InvalidEnumArgumentException(parameterName, input, typeof(T));
             }
-            throw new InvalidEnumArgumentException(message);
+            throw customException ?? new InvalidEnumArgumentException(message);
         }
 
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="InvalidEnumArgumentException" /> if <paramref name="input"/> is not a valid enum value.
+    /// Throws an <see cref="InvalidEnumArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> is not a valid enum value.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not out of range.</returns>
     /// <exception cref="InvalidEnumArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static T EnumOutOfRange<T>(this IGuardClause guardClause,
         T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null) where T : struct, Enum
+        string? message = null,
+        Exception? customException = null) where T : struct, Enum
     {
         if (!Enum.IsDefined(typeof(T), input))
         {
             if (string.IsNullOrEmpty(message))
             {
-                throw new InvalidEnumArgumentException(parameterName, Convert.ToInt32(input), typeof(T));
+                throw customException ?? new InvalidEnumArgumentException(parameterName, Convert.ToInt32(input), typeof(T));
             }
-            throw new InvalidEnumArgumentException(message);
+            throw customException ?? new InvalidEnumArgumentException(message);
         }
 
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentOutOfRangeException" /> if  any <paramref name="input"/>'s item is less than <paramref name="rangeFrom"/> or greater than <paramref name="rangeTo"/>.
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> or a custom <see cref="Exception" /> if  any <paramref name="input"/>'s item is less than <paramref name="rangeFrom"/> or greater than <paramref name="rangeTo"/>.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
@@ -98,14 +107,17 @@ public static partial class GuardClauseExtensions
     /// <param name="rangeFrom"></param>
     /// <param name="rangeTo"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if any item is not out of range.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
+    /// <exception cref="Exception"></exception>
     public static IEnumerable<T> OutOfRange<T>(this IGuardClause guardClause,
         IEnumerable<T> input,
         string parameterName,
         T rangeFrom, T rangeTo,
-        string? message = null) where T : IComparable, IComparable<T>
+        string? message = null,
+        Exception? customException = null) where T : IComparable, IComparable<T>
     {
         if (rangeFrom.CompareTo(rangeTo) > 0)
         {
@@ -116,57 +128,61 @@ public static partial class GuardClauseExtensions
         {
             if (string.IsNullOrEmpty(message))
             {
-                throw new ArgumentOutOfRangeException(parameterName, message ?? $"Input {parameterName} had out of range item(s)");
+                throw customException ?? new ArgumentOutOfRangeException(parameterName, message ?? $"Input {parameterName} had out of range item(s)");
             }
-            throw new ArgumentOutOfRangeException(parameterName, message);
+            throw customException ?? new ArgumentOutOfRangeException(parameterName, message);
         }
 
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="input" /> is null.
-    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input" /> is not in the range of valid SqlDateTime values.
+    /// Throws an <see cref="ArgumentNullException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is null.
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is not in the range of valid SqlDateTime values.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
+    /// <exception cref="Exception"></exception>
     public static DateTime NullOrOutOfSQLDateRange(this IGuardClause guardClause,
          [NotNull][ValidatedNotNull] DateTime? input,
          [CallerArgumentExpression("input")] string? parameterName = null,
-         string? message = null)
+         string? message = null, Exception? customException = null)
     {
-        guardClause.Null(input, nameof(input));
-        return OutOfSQLDateRange(guardClause, input.Value, parameterName, message);
+        guardClause.Null(input, nameof(input),customException: customException);
+        return OutOfSQLDateRange(guardClause, input.Value, parameterName, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input" /> is not in the range of valid SqlDateTime values.
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is not in the range of valid SqlDateTime values.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
+    /// <exception cref="Exception"></exception>
     public static DateTime OutOfSQLDateRange(this IGuardClause guardClause,
         DateTime input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null, Exception? customException = null)
     {
         // System.Data is unavailable in .NET Standard so we can't use SqlDateTime.
         const long sqlMinDateTicks = 552877920000000000;
         const long sqlMaxDateTicks = 3155378975999970000;
 
-        return NullOrOutOfRangeInternal<DateTime>(guardClause, input, parameterName, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks), message);
+        return NullOrOutOfRangeInternal<DateTime>(guardClause, input, parameterName, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks), message,customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input"/> is less than <paramref name="rangeFrom"/> or greater than <paramref name="rangeTo"/>.
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> is less than <paramref name="rangeFrom"/> or greater than <paramref name="rangeTo"/>.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
@@ -174,22 +190,24 @@ public static partial class GuardClauseExtensions
     /// <param name="rangeFrom"></param>
     /// <param name="rangeTo"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not out of range.</returns>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
+    /// <exception cref="Exception"></exception>
     public static T OutOfRange<T>(this IGuardClause guardClause,
         T input,
         string parameterName,
         [NotNull][ValidatedNotNull] T rangeFrom,
         [NotNull][ValidatedNotNull] T rangeTo,
-        string? message = null) where T : IComparable, IComparable<T>
+        string? message = null, Exception? customException = null) where T : IComparable, IComparable<T>
     {
-        return NullOrOutOfRangeInternal<T>(guardClause, input, parameterName, rangeFrom, rangeTo, message);
+        return NullOrOutOfRangeInternal<T>(guardClause, input, parameterName, rangeFrom, rangeTo, message,customException);
     }
 
 
     /// <summary>
-    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="input" /> is null.
-    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input"/> is less than <paramref name="rangeFrom"/> or greater than <paramref name="rangeTo"/>.
+    /// Throws an <see cref="ArgumentNullException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is null.
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> is less than <paramref name="rangeFrom"/> or greater than <paramref name="rangeTo"/>.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
@@ -197,24 +215,26 @@ public static partial class GuardClauseExtensions
     /// <param name="rangeFrom"></param>
     /// <param name="rangeTo"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not not null or out of range.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
+    /// <exception cref="Exception"></exception>
     public static T NullOrOutOfRange<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] T? input,
         string parameterName,
         [NotNull][ValidatedNotNull] T rangeFrom,
         [NotNull][ValidatedNotNull] T rangeTo,
-        string? message = null) where T : IComparable<T>
+        string? message = null, Exception? customException = null) where T : IComparable<T>
     {
-        guardClause.Null(input, nameof(input));
-        return NullOrOutOfRangeInternal(guardClause, input, parameterName, rangeFrom, rangeTo, message);
+        guardClause.Null(input, nameof(input),customException: customException);
+        return NullOrOutOfRangeInternal(guardClause, input, parameterName, rangeFrom, rangeTo, message,customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="input" /> is null.
-    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="input"/> is less than <paramref name="rangeFrom"/> or greater than <paramref name="rangeTo"/>.
+    /// Throws an <see cref="ArgumentNullException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is null.
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> or a custom <see cref="Exception" /> if <paramref name="input"/> is less than <paramref name="rangeFrom"/> or greater than <paramref name="rangeTo"/>.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
@@ -222,19 +242,21 @@ public static partial class GuardClauseExtensions
     /// <param name="rangeFrom"></param>
     /// <param name="rangeTo"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not not null or out of range.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
+    /// <exception cref="Exception"></exception>
     public static T NullOrOutOfRange<T>(this IGuardClause guardClause,
         [NotNull][ValidatedNotNull] T? input,
         string parameterName,
         [NotNull][ValidatedNotNull] T rangeFrom,
         [NotNull][ValidatedNotNull] T rangeTo,
-        string? message = null) where T : struct, IComparable<T>
+        string? message = null, Exception? customException = null) where T : struct, IComparable<T>
     {
-        guardClause.Null(input, nameof(input));
-        return NullOrOutOfRangeInternal<T>(guardClause, input.Value, parameterName, rangeFrom, rangeTo, message);
+        guardClause.Null(input, nameof(input), customException: customException);
+        return NullOrOutOfRangeInternal<T>(guardClause, input.Value, parameterName, rangeFrom, rangeTo, message, customException);
     }
 
     /// <exception cref="ArgumentNullException"></exception>
@@ -245,7 +267,8 @@ public static partial class GuardClauseExtensions
         string? parameterName,
         [NotNull][ValidatedNotNull] T? rangeFrom,
         [NotNull][ValidatedNotNull] T? rangeTo,
-        string? message = null) where T : IComparable<T>?
+        string? message = null,
+        Exception? customException = null) where T : IComparable<T>?
     {
         Guard.Against.Null(input, nameof(input));
         Guard.Against.Null(parameterName, nameof(parameterName));
@@ -261,9 +284,9 @@ public static partial class GuardClauseExtensions
         {
             if (string.IsNullOrEmpty(message))
             {
-                throw new ArgumentOutOfRangeException(parameterName, $"Input {parameterName} was out of range");
+                throw customException ?? new ArgumentOutOfRangeException(parameterName, $"Input {parameterName} was out of range");
             }
-            throw new ArgumentOutOfRangeException(parameterName, message);
+            throw customException ?? new ArgumentOutOfRangeException(parameterName, message);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
@@ -18,7 +18,7 @@ public static partial class GuardClauseExtensions
     /// <param name="maxLength"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -28,12 +28,12 @@ public static partial class GuardClauseExtensions
         int maxLength,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
         Guard.Against.Negative<int>(maxLength - minLength, parameterName: "min or max length",
             message: "Min length must be equal or less than max length.");
-        Guard.Against.StringTooShort(input, minLength, nameof(minLength), customException: customException);
-        Guard.Against.StringTooLong(input, maxLength, nameof(maxLength), customException: customException);
+        Guard.Against.StringTooShort(input, minLength, nameof(minLength), exception: exception);
+        Guard.Against.StringTooLong(input, maxLength, nameof(maxLength), exception: exception);
 
         return input;
     }
@@ -46,7 +46,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not out of range.</returns>
     /// <exception cref="InvalidEnumArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -54,15 +54,15 @@ public static partial class GuardClauseExtensions
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null) where T : struct, Enum
+        Exception? exception = null) where T : struct, Enum
     {
         if (!Enum.IsDefined(typeof(T), input))
         {
             if (string.IsNullOrEmpty(message))
             {
-                throw customException ?? new InvalidEnumArgumentException(parameterName, input, typeof(T));
+                throw exception ?? new InvalidEnumArgumentException(parameterName, input, typeof(T));
             }
-            throw customException ?? new InvalidEnumArgumentException(message);
+            throw exception ?? new InvalidEnumArgumentException(message);
         }
 
         return input;
@@ -76,7 +76,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not out of range.</returns>
     /// <exception cref="InvalidEnumArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -84,15 +84,15 @@ public static partial class GuardClauseExtensions
         T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null) where T : struct, Enum
+        Exception? exception = null) where T : struct, Enum
     {
         if (!Enum.IsDefined(typeof(T), input))
         {
             if (string.IsNullOrEmpty(message))
             {
-                throw customException ?? new InvalidEnumArgumentException(parameterName, Convert.ToInt32(input), typeof(T));
+                throw exception ?? new InvalidEnumArgumentException(parameterName, Convert.ToInt32(input), typeof(T));
             }
-            throw customException ?? new InvalidEnumArgumentException(message);
+            throw exception ?? new InvalidEnumArgumentException(message);
         }
 
         return input;
@@ -107,7 +107,7 @@ public static partial class GuardClauseExtensions
     /// <param name="rangeFrom"></param>
     /// <param name="rangeTo"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if any item is not out of range.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
@@ -117,7 +117,7 @@ public static partial class GuardClauseExtensions
         string parameterName,
         T rangeFrom, T rangeTo,
         string? message = null,
-        Exception? customException = null) where T : IComparable, IComparable<T>
+        Exception? exception = null) where T : IComparable, IComparable<T>
     {
         if (rangeFrom.CompareTo(rangeTo) > 0)
         {
@@ -128,9 +128,9 @@ public static partial class GuardClauseExtensions
         {
             if (string.IsNullOrEmpty(message))
             {
-                throw customException ?? new ArgumentOutOfRangeException(parameterName, message ?? $"Input {parameterName} had out of range item(s)");
+                throw exception ?? new ArgumentOutOfRangeException(parameterName, message ?? $"Input {parameterName} had out of range item(s)");
             }
-            throw customException ?? new ArgumentOutOfRangeException(parameterName, message);
+            throw exception ?? new ArgumentOutOfRangeException(parameterName, message);
         }
 
         return input;
@@ -144,7 +144,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
@@ -152,10 +152,10 @@ public static partial class GuardClauseExtensions
     public static DateTime NullOrOutOfSQLDateRange(this IGuardClause guardClause,
          [NotNull][ValidatedNotNull] DateTime? input,
          [CallerArgumentExpression("input")] string? parameterName = null,
-         string? message = null, Exception? customException = null)
+         string? message = null, Exception? exception = null)
     {
-        guardClause.Null(input, nameof(input),customException: customException);
-        return OutOfSQLDateRange(guardClause, input.Value, parameterName, message, customException);
+        guardClause.Null(input, nameof(input),exception: exception);
+        return OutOfSQLDateRange(guardClause, input.Value, parameterName, message, exception);
     }
 
     /// <summary>
@@ -165,20 +165,20 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     /// <exception cref="Exception"></exception>
     public static DateTime OutOfSQLDateRange(this IGuardClause guardClause,
         DateTime input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? customException = null)
+        string? message = null, Exception? exception = null)
     {
         // System.Data is unavailable in .NET Standard so we can't use SqlDateTime.
         const long sqlMinDateTicks = 552877920000000000;
         const long sqlMaxDateTicks = 3155378975999970000;
 
-        return NullOrOutOfRangeInternal<DateTime>(guardClause, input, parameterName, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks), message,customException);
+        return NullOrOutOfRangeInternal<DateTime>(guardClause, input, parameterName, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks), message,exception);
     }
 
     /// <summary>
@@ -190,7 +190,7 @@ public static partial class GuardClauseExtensions
     /// <param name="rangeFrom"></param>
     /// <param name="rangeTo"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not out of range.</returns>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     /// <exception cref="Exception"></exception>
@@ -199,9 +199,9 @@ public static partial class GuardClauseExtensions
         string parameterName,
         [NotNull][ValidatedNotNull] T rangeFrom,
         [NotNull][ValidatedNotNull] T rangeTo,
-        string? message = null, Exception? customException = null) where T : IComparable, IComparable<T>
+        string? message = null, Exception? exception = null) where T : IComparable, IComparable<T>
     {
-        return NullOrOutOfRangeInternal<T>(guardClause, input, parameterName, rangeFrom, rangeTo, message,customException);
+        return NullOrOutOfRangeInternal<T>(guardClause, input, parameterName, rangeFrom, rangeTo, message,exception);
     }
 
 
@@ -215,7 +215,7 @@ public static partial class GuardClauseExtensions
     /// <param name="rangeFrom"></param>
     /// <param name="rangeTo"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not not null or out of range.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
@@ -226,10 +226,10 @@ public static partial class GuardClauseExtensions
         string parameterName,
         [NotNull][ValidatedNotNull] T rangeFrom,
         [NotNull][ValidatedNotNull] T rangeTo,
-        string? message = null, Exception? customException = null) where T : IComparable<T>
+        string? message = null, Exception? exception = null) where T : IComparable<T>
     {
-        guardClause.Null(input, nameof(input),customException: customException);
-        return NullOrOutOfRangeInternal(guardClause, input, parameterName, rangeFrom, rangeTo, message,customException);
+        guardClause.Null(input, nameof(input),exception: exception);
+        return NullOrOutOfRangeInternal(guardClause, input, parameterName, rangeFrom, rangeTo, message,exception);
     }
 
     /// <summary>
@@ -242,7 +242,7 @@ public static partial class GuardClauseExtensions
     /// <param name="rangeFrom"></param>
     /// <param name="rangeTo"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not not null or out of range.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
@@ -253,10 +253,10 @@ public static partial class GuardClauseExtensions
         string parameterName,
         [NotNull][ValidatedNotNull] T rangeFrom,
         [NotNull][ValidatedNotNull] T rangeTo,
-        string? message = null, Exception? customException = null) where T : struct, IComparable<T>
+        string? message = null, Exception? exception = null) where T : struct, IComparable<T>
     {
-        guardClause.Null(input, nameof(input), customException: customException);
-        return NullOrOutOfRangeInternal<T>(guardClause, input.Value, parameterName, rangeFrom, rangeTo, message, customException);
+        guardClause.Null(input, nameof(input), exception: exception);
+        return NullOrOutOfRangeInternal<T>(guardClause, input.Value, parameterName, rangeFrom, rangeTo, message, exception);
     }
 
     /// <exception cref="ArgumentNullException"></exception>
@@ -268,7 +268,7 @@ public static partial class GuardClauseExtensions
         [NotNull][ValidatedNotNull] T? rangeFrom,
         [NotNull][ValidatedNotNull] T? rangeTo,
         string? message = null,
-        Exception? customException = null) where T : IComparable<T>?
+        Exception? exception = null) where T : IComparable<T>?
     {
         Guard.Against.Null(input, nameof(input));
         Guard.Against.Null(parameterName, nameof(parameterName));
@@ -284,9 +284,9 @@ public static partial class GuardClauseExtensions
         {
             if (string.IsNullOrEmpty(message))
             {
-                throw customException ?? new ArgumentOutOfRangeException(parameterName, $"Input {parameterName} was out of range");
+                throw exception ?? new ArgumentOutOfRangeException(parameterName, $"Input {parameterName} was out of range");
             }
-            throw customException ?? new ArgumentOutOfRangeException(parameterName, message);
+            throw exception ?? new ArgumentOutOfRangeException(parameterName, message);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstStringLengthExtensions.cs
+++ b/src/GuardClauses/GuardAgainstStringLengthExtensions.cs
@@ -17,7 +17,7 @@ public static partial class GuardClauseExtensions
     /// <param name="minLength"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -26,12 +26,12 @@ public static partial class GuardClauseExtensions
         int minLength,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
         Guard.Against.NegativeOrZero(minLength, nameof(minLength));
         if (input.Length < minLength)
         {
-            throw customException ?? new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too short. Minimum length is {minLength}.", parameterName);
+            throw exception ?? new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too short. Minimum length is {minLength}.", parameterName);
         }
         return input;
     }
@@ -44,7 +44,7 @@ public static partial class GuardClauseExtensions
     /// <param name="maxLength"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -53,12 +53,12 @@ public static partial class GuardClauseExtensions
         int maxLength,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
         Guard.Against.NegativeOrZero(maxLength, nameof(maxLength));
         if (input.Length > maxLength)
         {
-            throw customException ?? new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too long. Maximum length is {maxLength}.", parameterName);
+            throw exception ?? new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too long. Maximum length is {maxLength}.", parameterName);
         }
         return input;
     }

--- a/src/GuardClauses/GuardAgainstStringLengthExtensions.cs
+++ b/src/GuardClauses/GuardAgainstStringLengthExtensions.cs
@@ -10,49 +10,55 @@ namespace Ardalis.GuardClauses;
 public static partial class GuardClauseExtensions
 {
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if string <paramref name="input"/> is too short.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if string <paramref name="input"/> is too short.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="minLength"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static string StringTooShort(this IGuardClause guardClause,
         string input,
         int minLength,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
         Guard.Against.NegativeOrZero(minLength, nameof(minLength));
         if (input.Length < minLength)
         {
-            throw new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too short. Minimum length is {minLength}.", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too short. Minimum length is {minLength}.", parameterName);
         }
         return input;
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if string <paramref name="input"/> is too long.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if string <paramref name="input"/> is too long.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="maxLength"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static string StringTooLong(this IGuardClause guardClause,
         string input,
         int maxLength,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
         Guard.Against.NegativeOrZero(maxLength, nameof(maxLength));
         if (input.Length > maxLength)
         {
-            throw new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too long. Maximum length is {maxLength}.", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too long. Maximum length is {maxLength}.", parameterName);
         }
         return input;
     }

--- a/src/GuardClauses/GuardAgainstStringLengthExtensions.cs
+++ b/src/GuardClauses/GuardAgainstStringLengthExtensions.cs
@@ -28,7 +28,7 @@ public static partial class GuardClauseExtensions
         string? message = null,
         Exception? exception = null)
     {
-        Guard.Against.NegativeOrZero(minLength, nameof(minLength));
+        Guard.Against.NegativeOrZero(minLength, nameof(minLength), exception: exception);
         if (input.Length < minLength)
         {
             throw exception ?? new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too short. Minimum length is {minLength}.", parameterName);
@@ -55,7 +55,7 @@ public static partial class GuardClauseExtensions
         string? message = null,
         Exception? exception = null)
     {
-        Guard.Against.NegativeOrZero(maxLength, nameof(maxLength));
+        Guard.Against.NegativeOrZero(maxLength, nameof(maxLength), exception: exception);
         if (input.Length > maxLength)
         {
             throw exception ?? new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too long. Maximum length is {maxLength}.", parameterName);

--- a/src/GuardClauses/GuardAgainstZeroExtensions.cs
+++ b/src/GuardClauses/GuardAgainstZeroExtensions.cs
@@ -13,7 +13,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -21,9 +21,9 @@ public static partial class GuardClauseExtensions
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
-        return Zero<int>(guardClause, input, parameterName!, message, customException);
+        return Zero<int>(guardClause, input, parameterName!, message, exception);
     }
 
     /// <summary>
@@ -33,7 +33,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -41,9 +41,9 @@ public static partial class GuardClauseExtensions
         long input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
-        return Zero<long>(guardClause, input, parameterName!, message, customException);
+        return Zero<long>(guardClause, input, parameterName!, message, exception);
     }
 
     /// <summary>
@@ -53,7 +53,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -61,9 +61,9 @@ public static partial class GuardClauseExtensions
         decimal input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
-        return Zero<decimal>(guardClause, input, parameterName!, message,customException);
+        return Zero<decimal>(guardClause, input, parameterName!, message,exception);
     }
 
     /// <summary>
@@ -73,7 +73,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -81,9 +81,9 @@ public static partial class GuardClauseExtensions
         float input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
-        return Zero<float>(guardClause, input, parameterName!, message, customException);
+        return Zero<float>(guardClause, input, parameterName!, message, exception);
     }
 
     /// <summary>
@@ -93,7 +93,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -101,9 +101,9 @@ public static partial class GuardClauseExtensions
         double input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
-        return Zero<double>(guardClause, input, parameterName!, message,customException);
+        return Zero<double>(guardClause, input, parameterName!, message,exception);
     }
 
     /// <summary>
@@ -112,16 +112,16 @@ public static partial class GuardClauseExtensions
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static TimeSpan Zero(this IGuardClause guardClause,
         TimeSpan input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        Exception? customException = null)
+        Exception? exception = null)
     {
-        return Zero<TimeSpan>(guardClause, input, parameterName!, customException:customException);
+        return Zero<TimeSpan>(guardClause, input, parameterName!, exception:exception);
     }
 
     /// <summary>
@@ -131,16 +131,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="customException"></param>
+    /// <param name="exception"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     private static T Zero<T>(this IGuardClause guardClause, T input, string parameterName, string? message = null,
-        Exception? customException = null) where T : struct
+        Exception? exception = null) where T : struct
     {
         if (EqualityComparer<T>.Default.Equals(input, default(T)))
         {
-            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} cannot be zero.", parameterName);
+            throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} cannot be zero.", parameterName);
         }
 
         return input;

--- a/src/GuardClauses/GuardAgainstZeroExtensions.cs
+++ b/src/GuardClauses/GuardAgainstZeroExtensions.cs
@@ -7,119 +7,140 @@ namespace Ardalis.GuardClauses;
 public static partial class GuardClauseExtensions
 {
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is zero.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static int Zero(this IGuardClause guardClause,
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
-        return Zero<int>(guardClause, input, parameterName!, message);
+        return Zero<int>(guardClause, input, parameterName!, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is zero.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static long Zero(this IGuardClause guardClause,
         long input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
-        return Zero<long>(guardClause, input, parameterName!, message);
+        return Zero<long>(guardClause, input, parameterName!, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is zero.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static decimal Zero(this IGuardClause guardClause,
         decimal input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
-        return Zero<decimal>(guardClause, input, parameterName!, message);
+        return Zero<decimal>(guardClause, input, parameterName!, message,customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is zero.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static float Zero(this IGuardClause guardClause,
         float input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
-        return Zero<float>(guardClause, input, parameterName!, message);
+        return Zero<float>(guardClause, input, parameterName!, message, customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is zero.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static double Zero(this IGuardClause guardClause,
         double input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null)
+        string? message = null,
+        Exception? customException = null)
     {
-        return Zero<double>(guardClause, input, parameterName!, message);
+        return Zero<double>(guardClause, input, parameterName!, message,customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is zero.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="Exception"></exception>
     public static TimeSpan Zero(this IGuardClause guardClause,
         TimeSpan input,
-        [CallerArgumentExpression("input")] string? parameterName = null)
+        [CallerArgumentExpression("input")] string? parameterName = null,
+        Exception? customException = null)
     {
-        return Zero<TimeSpan>(guardClause, input, parameterName!);
+        return Zero<TimeSpan>(guardClause, input, parameterName!, customException:customException);
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> if <paramref name="input" /> is zero.
+    /// Throws an <see cref="ArgumentException" /> or a custom <see cref="Exception" /> if <paramref name="input" /> is zero.
     /// </summary>
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
+    /// <param name="customException"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
-    private static T Zero<T>(this IGuardClause guardClause, T input, string parameterName, string? message = null) where T : struct
+    /// <exception cref="Exception"></exception>
+    private static T Zero<T>(this IGuardClause guardClause, T input, string parameterName, string? message = null,
+        Exception? customException = null) where T : struct
     {
         if (EqualityComparer<T>.Default.Equals(input, default(T)))
         {
-            throw new ArgumentException(message ?? $"Required input {parameterName} cannot be zero.", parameterName);
+            throw customException ?? new ArgumentException(message ?? $"Required input {parameterName} cannot be zero.", parameterName);
         }
 
         return input;

--- a/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
@@ -26,6 +26,16 @@ public class GuardAgainstDefault
         Assert.Throws<ArgumentException>("datetime", () => Guard.Against.Default(default(DateTime), "datetime"));
         Assert.Throws<ArgumentException>("object", () => Guard.Against.Default(default(object), "object"));
     }
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenDefaultValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>( () => Guard.Against.Default(default(string), "string", exception: customException));
+        Assert.Throws<Exception>( () => Guard.Against.Default(default(int), "int", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Default(default(Guid), "guid", exception: customException));
+        Assert.Throws<Exception>( () => Guard.Against.Default(default(DateTime), "datetime", exception: customException));
+        Assert.Throws<Exception>( () => Guard.Against.Default(default(object), "object", exception: customException));
+    }
 
     [Theory]
     [MemberData(nameof(GetNonDefaultTestVectors))]

--- a/test/GuardClauses.UnitTests/GuardAgainstExpression.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstExpression.cs
@@ -30,6 +30,15 @@ public class GuardAgainstExpression
     }
 
     [Fact]
+    public void GivenIntegerWhenTheExpressionEvaluatesToTrueThrowsCustomExceptionWhenSupplied()
+    {
+        Exception customException = new Exception();
+        int testCase = 10;
+        Assert.Throws<Exception>(() => Guard.Against.Expression((x) => x == 10, testCase, "Value cannot be 10", exception: customException));
+    }
+
+
+    [Fact]
     public void GivenIntegerWhenTheExpressionEvaluatesToFalseDoesNothing()
     {
         int testCase = 10;
@@ -44,6 +53,15 @@ public class GuardAgainstExpression
     }
 
     [Fact]
+    public void GivenDoubleWhenTheExpressionEvaluatesToTrueThrowsCustomExceptionWhenSupplied()
+    {
+        Exception customException = new Exception();
+        double testCase = 1.1;
+        Assert.Throws<Exception>(() => Guard.Against.Expression((x) => x == 1.1, testCase, "Value cannot be 1.1", exception: customException));
+    }
+
+
+    [Fact]
     public void GivenDoubleWhenTheExpressionEvaluatesToFalseDoesNothing()
     {
         double testCase = 1.1;
@@ -56,6 +74,15 @@ public class GuardAgainstExpression
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.Expression((x) => x.FieldName == "FieldValue", test, "FieldValue is not matching"));
     }
+
+    [Theory]
+    [MemberData(nameof(GetCustomStruct))]
+    public void GivenCustomStructWhenTheExpressionEvaluatesToTrueThrowsCustomExceptionWhenSupplied(CustomStruct test)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Expression((x) => x.FieldName == "FieldValue", test, "FieldValue is not matching", exception: customException));
+    }
+
 
     [Theory]
     [MemberData(nameof(GetCustomStruct))]

--- a/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
@@ -31,6 +31,20 @@ public class GuardAgainstInvalidFormatTests
     }
 
     [Theory]
+    [InlineData("aaa", @"\d{1,6}")]
+    [InlineData("50XA", @"[0-9a-fA-F]{1,6}")]
+    [InlineData("2GudhUtG", @"[a-fA-F]+")]
+    [InlineData("sDHSTRY", @"[A-Z]+")]
+    [InlineData("3F498792", @"\d+")]
+    [InlineData("", @"\d+")]
+    public void ThrowsCustomExceptionWhenSuppliedGivenGivenIncorrectFormat(string input, string regexPattern)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.InvalidFormat(input, nameof(input), regexPattern, exception: customException));
+    }
+
+
+    [Theory]
     [InlineData(null, "Input parameterName was not in required format (Parameter 'parameterName')")]
     [InlineData("Please provide value in a correct format", "Please provide value in a correct format (Parameter 'parameterName')")]
     public void ErrorMessageMatchesExpected(string? customMessage, string? expectedMessage)

--- a/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
@@ -36,10 +36,26 @@ public class GuardAgainstNegative
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNegativeIntValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Negative(-1, "negative", exception: customException));
+    }
+
+
+    [Fact]
     public void ThrowsGivenNegativeLongValue()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1L, "negative"));
     }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNegativeLongValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Negative(-1L, "negative", exception: customException));
+    }
+
 
     [Fact]
     public void ThrowsGivenNegativeDecimalValue()
@@ -48,10 +64,26 @@ public class GuardAgainstNegative
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNegativeDecimalValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Negative(-1.0M, "negative", exception: customException));
+    }
+
+
+    [Fact]
     public void ThrowsGivenNegativeFloatValue()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0f, "negative"));
     }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNegativeFloatValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Negative(-1.0f, "negative", exception: customException));
+    }
+
 
     [Fact]
     public void ThrowsGivenNegativeDoubleValue()
@@ -60,10 +92,26 @@ public class GuardAgainstNegative
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNegativeDoubleValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Negative(-1.0, "negative", exception: customException));
+    }
+
+
+    [Fact]
     public void ThrowsGivenNegativeTimeSpanValue()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.Negative(TimeSpan.FromSeconds(-1), "negative"));
     }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNegativeTimeSpanValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Negative(TimeSpan.FromSeconds(-1), "negative", exception: customException));
+    }
+
 
     [Fact]
     public void ReturnsExpectedValueGivenNonNegativeIntValue()

--- a/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
@@ -25,10 +25,26 @@ public class GuardAgainstNegativeOrZero
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroIntValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0, "intZero", exception: customException));
+    }
+
+
+    [Fact]
     public void ThrowsGivenZeroLongValue()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0L, "longZero"));
     }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroLongValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0L, "longZero", exception: customException));
+    }
+
 
     [Fact]
     public void ThrowsGivenZeroDecimalValue()
@@ -37,10 +53,26 @@ public class GuardAgainstNegativeOrZero
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroDecimalValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0M, "decimalZero", exception: customException));
+    }
+
+
+    [Fact]
     public void ThrowsGivenZeroFloatValue()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0f, "floatZero"));
     }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroFloatValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0f, "floatZero", exception: customException));
+    }
+
 
     [Fact]
     public void ThrowsGivenZeroDoubleValue()
@@ -49,9 +81,24 @@ public class GuardAgainstNegativeOrZero
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroDoubleValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0.0, "doubleZero", exception: customException));
+    }
+
+
+    [Fact]
     public void ThrowsGivenZeroTimeSpanValue()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(TimeSpan.Zero, "timespanZero"));
+    }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroTimeSpanValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(TimeSpan.Zero, "timespanZero", exception: customException));
     }
 
 
@@ -63,11 +110,29 @@ public class GuardAgainstNegativeOrZero
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNegativeIntValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1, "intNegative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-42, "intNegative", exception: customException));
+    }
+
+
+    [Fact]
     public void ThrowsGivenNegativeLongValue()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1L, "longNegative"));
         Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-456L, "longNegative"));
     }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNegativeLongValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1L, "longNegative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-456L, "longNegative", exception: customException));
+    }
+
 
     [Fact]
     public void ThrowsGivenNegativeDecimalValue()
@@ -77,10 +142,29 @@ public class GuardAgainstNegativeOrZero
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNegativeDecimalValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1M, "decimalNegative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-567M, "decimalNegative", exception: customException));
+    }
+
+
+
+
+    [Fact]
     public void ThrowsGivenNegativeFloatValue()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-1f, "floatNegative"));
         Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-4567f, "floatNegative"));
+    }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNegativeFloatValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1f, "floatNegative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-4567f, "floatNegative", exception: customException));
     }
 
     [Fact]
@@ -90,11 +174,28 @@ public class GuardAgainstNegativeOrZero
         Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(-456.453, "doubleNegative"));
     }
 
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNegativeDoubleValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1.0, "doubleNegative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-456.453, "doubleNegative", exception: customException));
+    }
+
     [Fact]
     public void ThrowsGivenNegativeTimeSpanValue()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(-1), "timespanNegative"));
         Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(-456), "timespanNegative"));
+    }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNegativeTimeSpanValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(-1), "timespanNegative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(-456), "timespanNegative", exception: customException));
     }
 
     [Fact]

--- a/test/GuardClauses.UnitTests/GuardAgainstNotFound.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNotFound.cs
@@ -24,6 +24,14 @@ public class GuardAgainstNotFound
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNullValue()
+    {
+        object obj = null!;
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NotFound(1, obj, "null", exception: customException));
+    }
+
+    [Fact]
     public void ReturnsExpectedValueWhenGivenNonNullValue()
     {
         Assert.Equal("", Guard.Against.NotFound("mykey", "", "string"));

--- a/test/GuardClauses.UnitTests/GuardAgainstNull.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNull.cs
@@ -24,6 +24,14 @@ public class GuardAgainstNull
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNullValue()
+    {
+        object obj = null!;
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Null(obj, "null", exception: customException));
+    }
+
+    [Fact]
     public void ReturnsExpectedValueWhenGivenNonNullValue()
     {
         Assert.Equal("", Guard.Against.Null("", "string"));

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
@@ -43,9 +43,23 @@ public class GuardAgainstNullOrEmpty
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenEmptyString()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NullOrEmpty("", "emptyString", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsGivenEmptyStringSpan()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.Empty("".AsSpan(), "emptyStringSpan"));
+    }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenEmptyStringSpan()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Empty("".AsSpan(), "emptyStringSpan", exception: customException));
     }
 
     [Fact]
@@ -62,10 +76,25 @@ public class GuardAgainstNullOrEmpty
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenEmptyGuid()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NullOrEmpty(Guid.Empty, "emptyGuid", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsGivenEmptyEnumerable()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Enumerable.Empty<string>(), "emptyStringEnumerable"));
     }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenEmptyEnumerable()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NullOrEmpty(Enumerable.Empty<string>(), "emptyStringEnumerable", exception: customException));
+    }
+
 
     [Fact]
     public void ReturnsExpectedValueWhenGivenValidValue()

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrInvalidInput.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrInvalidInput.cs
@@ -25,6 +25,15 @@ public class GuardAgainstNullOrInvalidInput
     }
 
     [Theory]
+    [ClassData(typeof(ArgumentExceptionClassData))]
+    public void ThrowsCustomExceptionWhenSuppliedArgumentExceptionWhenInputIsInvalid(string? input, Func<string, bool> func)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(
+            () => Guard.Against.NullOrInvalidInput(input, "string", func, exception: customException));
+    }
+
+    [Theory]
     [ClassData(typeof(ValidClassData))]
     public void ReturnsExceptedValueWhenGivenValidInput(int input, Func<int, bool> func)
     {

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfRangeForClassIComparable.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfRangeForClassIComparable.cs
@@ -42,13 +42,21 @@ namespace GuardClauses.UnitTests
             Guard.Against.NullOrOutOfRange(new TestObj(2), "index", new TestObj(1), new TestObj(3));
             Guard.Against.NullOrOutOfRange(new TestObj(3), "index", new TestObj(1), new TestObj(3));
         }
-
         [Fact]
         public void ThrowsGivenOutOfRangeValue()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.NullOrOutOfRange(new TestObj(-1), "index", new TestObj(1), new TestObj(3)));
             Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.NullOrOutOfRange(new TestObj(0), "index", new TestObj(1), new TestObj(3)));
             Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.NullOrOutOfRange(new TestObj(4), "index", new TestObj(1), new TestObj(3)));
+        }
+
+        [Fact]
+        public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue()
+        {
+            Exception customException = new Exception();
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(new TestObj(-1), "index", new TestObj(1), new TestObj(3), exception: customException));
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(new TestObj(0), "index", new TestObj(1), new TestObj(3), exception: customException));
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(new TestObj(4), "index", new TestObj(1), new TestObj(3), exception: customException));
         }
 
         [Fact]
@@ -63,14 +71,12 @@ namespace GuardClauses.UnitTests
         public void ThrowsGivenInvalidNullArgumentValue()
         {
 #pragma warning disable CS8631 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.
-
             Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrOutOfRange(null, "index", new TestObj(3), new TestObj(1)));
             Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrOutOfRange(new TestObj(0), "index", null, new TestObj(1)));
             Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrOutOfRange(new TestObj(4), "index", new TestObj(3), null));
-
 #pragma warning restore CS8631
         }
-        
+
         [Fact]
         public void ReturnsExpectedValueGivenInRangeValue()
         {

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfRangeForInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfRangeForInt.cs
@@ -26,6 +26,16 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [InlineData(-1, 1, 3)]
+        [InlineData(0, 1, 3)]
+        [InlineData(4, 1, 3)]
+        public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(int input, int rangeFrom, int rangeTo)
+        {
+            Exception customException = new Exception();
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+        }
+
+        [Theory]
         [InlineData(-1, 3, 1)]
         [InlineData(0, 3, 1)]
         [InlineData(4, 3, 1)]

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfRangeForNullableInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfRangeForNullableInt.cs
@@ -26,6 +26,16 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [InlineData(-1, 1, 3)]
+        [InlineData(0, 1, 3)]
+        [InlineData(4, 1, 3)]
+        public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(int? input, int rangeFrom, int rangeTo)
+        {
+            Exception customException = new Exception();
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+        }
+
+        [Theory]
         [InlineData(-1, 3, 1)]
         [InlineData(0, 3, 1)]
         [InlineData(4, 3, 1)]
@@ -33,6 +43,7 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NullOrOutOfRange(input, "index", rangeFrom, rangeTo));
         }
+
 
         [Theory]
         [InlineData(1, 1, 1, 1)]
@@ -49,5 +60,13 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrOutOfRange(null, "index", -10, 10));
         }
+
+        [Fact]
+        public void ThrowsCustomExceptionWhenSuppliedGivenInvalidNullArgumentValue()
+        {
+            Exception customException = new Exception();
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(null, "index", -10, 10, exception: customException));
+        }
+
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfSQLDateRange.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfSQLDateRange.cs
@@ -22,6 +22,22 @@ namespace GuardClauses.UnitTests
             Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.NullOrOutOfSQLDateRange(date, nameof(date)));
         }
 
+        [Theory]
+        [InlineData(1)]
+        [InlineData(60)]
+        [InlineData(60 * 60)]
+        [InlineData(60 * 60 * 24)]
+        [InlineData(60 * 60 * 24 * 30)]
+        [InlineData(60 * 60 * 24 * 30 * 365)]
+        public void ThrowsCustomExceptionWhenSuppliedGivenValueBelowMinDate(int offsetInSeconds)
+        {
+            DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-offsetInSeconds);
+            Exception customException = new Exception();
+
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfSQLDateRange(date, nameof(date), exception: customException));
+        }
+
+
         [Fact]
         public void DoNothingGivenCurrentDate()
         {
@@ -86,6 +102,12 @@ namespace GuardClauses.UnitTests
             Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrOutOfSQLDateRange(null, "index"));
         }
 
+        [Fact]
+        public void ThrowsCustomExceptionWhenSuppliedGivenInvalidNullArgumentValue()
+        {
+            Exception customException = new Exception();
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfSQLDateRange(null, "index", exception: customException));
+        }
         public static IEnumerable<object[]> GetSqlDateTimeTestVectors()
         {
             var now = DateTime.Now;

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -26,15 +26,36 @@ public class GuardAgainstNullOrWhiteSpace
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNullValue()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NullOrWhiteSpace(null, "null", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsGivenEmptyString()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace("", "emptystring"));
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenEmptyString()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NullOrWhiteSpace("", "emptystring", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsGivenEmptyStringSpan()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.WhiteSpace("".AsSpan(), "emptyStringSpan"));
+    }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenEmptyStringSpan()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.WhiteSpace("".AsSpan(), "emptyStringSpan", exception: customException));
     }
 
     [Theory]
@@ -45,6 +66,17 @@ public class GuardAgainstNullOrWhiteSpace
         Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring"));
         Assert.Throws<ArgumentException>(() => Guard.Against.WhiteSpace(whiteSpaceString.AsSpan(), "whiteSpaceStringSpan"));
     }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    public void ThrowsCustomExceptionWhenSuppliedGivenWhiteSpaceString(string? whiteSpaceString)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.WhiteSpace(whiteSpaceString.AsSpan(), "whiteSpaceStringSpan", exception: customException));
+    }
+
 
     [Theory]
     [InlineData("a", "a")]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
@@ -18,7 +18,6 @@ public class GuardAgainstOutOfRangeForDateTime
         DateTime rangeTo = input.AddSeconds(rangeToOffset);
         Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
     }
-
     [Theory]
     [InlineData(1, 3)]
     [InlineData(-4, -3)]
@@ -31,6 +30,18 @@ public class GuardAgainstOutOfRangeForDateTime
     }
 
     [Theory]
+    [InlineData(1, 3)]
+    [InlineData(-4, -3)]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(int rangeFromOffset, int rangeToOffset)
+    {
+        DateTime input = DateTime.Now;
+        DateTime rangeFrom = input.AddSeconds(rangeFromOffset);
+        DateTime rangeTo = input.AddSeconds(rangeToOffset);
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+    }
+
+    [Theory]
     [InlineData(3, 1)]
     [InlineData(3, -1)]
     public void ThrowsGivenInvalidArgumentValue(int rangeFromOffset, int rangeToOffset)
@@ -40,6 +51,7 @@ public class GuardAgainstOutOfRangeForDateTime
         DateTime rangeTo = input.AddSeconds(rangeToOffset);
         Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(DateTime.Now, "index", rangeFrom, rangeTo));
     }
+
 
     [Theory]
     [InlineData(0, 0)]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
@@ -15,7 +15,6 @@ public class GuardAgainstOutOfRangeForDecimal
     {
         Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
     }
-
     [Theory]
     [InlineData(-1.0, 1.0, 3.0)]
     [InlineData(0.0, 1.0, 3.0)]
@@ -26,6 +25,16 @@ public class GuardAgainstOutOfRangeForDecimal
     }
 
     [Theory]
+    [InlineData(-1.0, 1.0, 3.0)]
+    [InlineData(0.0, 1.0, 3.0)]
+    [InlineData(4.0, 1.0, 3.0)]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(decimal input, decimal rangeFrom, decimal rangeTo)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+    }
+
+    [Theory]
     [InlineData(-1.0, 3.0, 1.0)]
     [InlineData(0.0, 3.0, 1.0)]
     [InlineData(4.0, 3.0, 1.0)]
@@ -33,6 +42,8 @@ public class GuardAgainstOutOfRangeForDecimal
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
     }
+
+
 
     [Theory]
     [InlineData(1.0, 0.0, 1.0, 1.0)]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
@@ -15,7 +15,6 @@ public class GuardAgainstOutOfRangeForDouble
     {
         Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
     }
-
     [Theory]
     [InlineData(-1.0, 1.0, 3.0)]
     [InlineData(0.0, 1.0, 3.0)]
@@ -26,6 +25,16 @@ public class GuardAgainstOutOfRangeForDouble
     }
 
     [Theory]
+    [InlineData(-1.0, 1.0, 3.0)]
+    [InlineData(0.0, 1.0, 3.0)]
+    [InlineData(4.0, 1.0, 3.0)]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(double input, double rangeFrom, double rangeTo)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+    }
+
+    [Theory]
     [InlineData(-1.0, 3.0, 1.0)]
     [InlineData(0.0, 3.0, 1.0)]
     [InlineData(4.0, 3.0, 1.0)]
@@ -33,6 +42,9 @@ public class GuardAgainstOutOfRangeForDouble
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
     }
+
+
+
 
     [Theory]
     [InlineData(1.0, 0.0, 1.0, 1.0)]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Ardalis.GuardClauses;
 using Xunit;
 
@@ -18,7 +19,6 @@ public class GuardAgainstOutOfRangeForEnum
         Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue));
     }
 
-
     [Theory]
     [InlineData(-1)]
     [InlineData(6)]
@@ -28,6 +28,17 @@ public class GuardAgainstOutOfRangeForEnum
         var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue)));
         Assert.Equal(nameof(enumValue), exception.ParamName);
     }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(6)]
+    [InlineData(10)]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(int enumValue)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.EnumOutOfRange<TestEnum>(enumValue, nameof(enumValue), exception: customException));
+    }
+
 
     [Theory]
     [InlineData(TestEnum.Budgie)]
@@ -50,6 +61,16 @@ public class GuardAgainstOutOfRangeForEnum
     {
         var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.EnumOutOfRange(enumValue, nameof(enumValue)));
         Assert.Equal(nameof(enumValue), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData((TestEnum)(-1))]
+    [InlineData((TestEnum)6)]
+    [InlineData((TestEnum)10)]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeEnum(TestEnum enumValue)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.EnumOutOfRange(enumValue, nameof(enumValue), exception: customException));
     }
 
     [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDecimal.cs
@@ -23,11 +23,20 @@ public class GuardAgainstOutOfRangeForEnumerableDecimal
     }
 
     [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, exception: customException));
+    }
+
+    [Theory]
     [ClassData(typeof(IncorrectRangeClassData))]
     public void ThrowsGivenInvalidArgumentValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
     }
+
 
     [Theory]
     [ClassData(typeof(CorrectClassData))]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDouble.cs
@@ -23,6 +23,14 @@ public class GuardAgainstOutOfRangeForEnumerableDouble
     }
 
     [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, exception: customException));
+    }
+
+    [Theory]
     [ClassData(typeof(IncorrectRangeClassData))]
     public void ThrowsGivenInvalidArgumentValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
     {

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableFloat.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableFloat.cs
@@ -23,6 +23,14 @@ public class GuardAgainstOutOfRangeForEnumerableFloat
     }
 
     [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, exception: customException));
+    }
+
+    [Theory]
     [ClassData(typeof(IncorrectRangeClassData))]
     public void ThrowsGivenInvalidArgumentValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
     {

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableInt.cs
@@ -23,6 +23,14 @@ public class GuardAgainstOutOfRangeForEnumerableInt
     }
 
     [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, exception: customException));
+    }
+
+    [Theory]
     [ClassData(typeof(IncorrectRangeClassData))]
     public void ThrowsGivenInvalidArgumentValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
     {

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableLong.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableLong.cs
@@ -23,6 +23,14 @@ public class GuardAgainstOutOfRangeForEnumerableLong
     }
 
     [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, exception: customException));
+    }
+
+    [Theory]
     [ClassData(typeof(IncorrectRangeClassData))]
     public void ThrowsGivenInvalidArgumentValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
     {

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableShort.cs
@@ -23,6 +23,14 @@ public class GuardAgainstOutOfRangeForEnumerableShort
     }
 
     [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, exception: customException));
+    }
+
+    [Theory]
     [ClassData(typeof(IncorrectRangeClassData))]
     public void ThrowsGivenInvalidArgumentValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
     {

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableTimeSpan.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableTimeSpan.cs
@@ -32,6 +32,18 @@ public class GuardAgainstOutOfRangeForEnumerableTimeSpan
     }
 
     [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+    {
+        var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan, exception: customException));
+    }
+
+    [Theory]
     [ClassData(typeof(IncorrectRangeClassData))]
     public void ThrowsGivenInvalidArgumentValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
     {

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
@@ -26,6 +26,16 @@ public class GuardAgainstOutOfRangeForFloat
     }
 
     [Theory]
+    [InlineData(-1.0, 1.0, 3.0)]
+    [InlineData(0.0, 1.0, 3.0)]
+    [InlineData(4.0, 1.0, 3.0)]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(float input, float rangeFrom, float rangeTo)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+    }
+
+    [Theory]
     [InlineData(-1.0, 3.0, 1.0)]
     [InlineData(0.0, 3.0, 1.0)]
     [InlineData(4.0, 3.0, 1.0)]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
@@ -26,6 +26,16 @@ public class GuardAgainstOutOfRangeForInt
     }
 
     [Theory]
+    [InlineData(-1, 1, 3)]
+    [InlineData(0, 1, 3)]
+    [InlineData(4, 1, 3)]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(int input, int rangeFrom, int rangeTo)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+    }
+
+    [Theory]
     [InlineData(-1, 3, 1)]
     [InlineData(0, 3, 1)]
     [InlineData(4, 3, 1)]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInvalidInput.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInvalidInput.cs
@@ -32,11 +32,28 @@ public class GuardAgainstOutOfRangeForInvalidInput
     }
 
     [Theory]
+    [ClassData(typeof(IncorrectClassData))]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue<T>(T input, Func<T, bool> func)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.InvalidInput(input, nameof(input), func, exception: customException));
+    }
+
+    [Theory]
     [ClassData(typeof(IncorrectAsyncClassData))]
     public async Task ThrowsGivenOutOfRangeValueAsync<T>(T input, Func<T, Task<bool>> func)
     {
         await Assert.ThrowsAsync<ArgumentException>(async () => await Guard.Against.InvalidInputAsync(input, nameof(input), func));
     }
+
+    [Theory]
+    [ClassData(typeof(IncorrectAsyncClassData))]
+    public async Task ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValueAsync<T>(T input, Func<T, Task<bool>> func)
+    {
+        Exception customException = new Exception();
+        await Assert.ThrowsAsync<Exception>(async () => await Guard.Against.InvalidInputAsync(input, nameof(input), func, exception: customException));
+    }
+
 
     [Theory]
     [ClassData(typeof(CorrectClassData))]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
@@ -15,7 +15,6 @@ public class GuardAgainstOutOfRangeForShort
     {
         Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo);
     }
-
     [Theory]
     [InlineData(-1, 1, 3)]
     [InlineData(0, 1, 3)]
@@ -23,6 +22,16 @@ public class GuardAgainstOutOfRangeForShort
     public void ThrowsGivenOutOfRangeValue(short input, short rangeFrom, short rangeTo)
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+    }
+
+    [Theory]
+    [InlineData(-1, 1, 3)]
+    [InlineData(0, 1, 3)]
+    [InlineData(4, 1, 3)]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(short input, short rangeFrom, short rangeTo)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
     }
 
     [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForStructIComparable.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForStructIComparable.cs
@@ -29,6 +29,17 @@ public class GuardAgainstOutOfRangeForStructIComparable
     }
 
     [Theory]
+    [InlineData(0, 1, 1, 1, 10, 10)]
+    [InlineData(1, 0, 1, 1, 10, 10)]
+    [InlineData(10, 11, 1, 1, 10, 10)]
+    [InlineData(11, 10, 1, 1, 10, 10)]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(int input1, int input2, int rangeFrom1, int rangeFrom2, int rangeTo1, int rangeTo2)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange((input1, input2), "tuple", (rangeFrom1, rangeFrom2), (rangeTo1, rangeTo2), exception: customException));
+    }
+
+    [Theory]
     [InlineData(0, 1, 10, 10, 1, 1)]
     [InlineData(1, 0, 10, 10, 1, 1)]
     [InlineData(10, 11, 10, 10, 1, 1)]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForTimeSpan.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForTimeSpan.cs
@@ -34,6 +34,20 @@ public class GuardAgainstOutOfRangeForTimeSpan
     }
 
     [Theory]
+    [InlineData(-1, 1, 3)]
+    [InlineData(0, 1, 3)]
+    [InlineData(4, 1, 3)]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(int input, int rangeFrom, int rangeTo)
+    {
+        var inputTimeSpan = TimeSpan.FromSeconds(input);
+        var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+        var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+        Exception customException = new Exception();
+
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan, exception: customException));
+    }
+
+    [Theory]
     [InlineData(-1, 3, 1)]
     [InlineData(0, 3, 1)]
     [InlineData(4, 3, 1)]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForUint.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForUint.cs
@@ -25,6 +25,15 @@ public class GuardAgainstOutOfRangeForUint
     }
 
     [Theory]
+    [InlineData(0, 1, 3)]
+    [InlineData(4, 1, 3)]
+    public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(uint input, uint rangeFrom, uint rangeTo)
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+    }
+
+    [Theory]
     [InlineData(0, 3, 1)]
     [InlineData(1, 3, 1)]
     [InlineData(4, 3, 1)]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
@@ -22,6 +22,21 @@ public class GuardAgainstOutOfSQLDateRange
         Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, nameof(date)));
     }
 
+    [Theory]
+    [InlineData(1)]
+    [InlineData(60)]
+    [InlineData(60 * 60)]
+    [InlineData(60 * 60 * 24)]
+    [InlineData(60 * 60 * 24 * 30)]
+    [InlineData(60 * 60 * 24 * 30 * 365)]
+    public void ThrowsCustomExceptionWhenSuppliedGivenValueBelowMinDate(int offsetInSeconds)
+    {
+        DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-offsetInSeconds);
+        Exception customException = new Exception();
+
+        Assert.Throws<Exception>(() => Guard.Against.OutOfSQLDateRange(date, nameof(date), exception: customException));
+    }
+
     [Fact]
     public void DoNothingGivenCurrentDate()
     {

--- a/test/GuardClauses.UnitTests/GuardAgainstStringLengthOutOfRange.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstStringLengthOutOfRange.cs
@@ -15,11 +15,17 @@ public class GuardAgainstStringLengthOutOfRange
         Guard.Against.LengthOutOfRange("a", 1, 4, "string");
         Guard.Against.LengthOutOfRange("a", 1, 4, "string");
     }
-
     [Fact]
     public void ThrowsGivenEmptyString()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.LengthOutOfRange("", 1, 2, "string"));
+    }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenEmptyString()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.LengthOutOfRange("", 1, 2, "string", exception: customException));
     }
 
     [Fact]
@@ -30,9 +36,24 @@ public class GuardAgainstStringLengthOutOfRange
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNonPositiveMinLength()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.LengthOutOfRange("", 0, 0, "string", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.LengthOutOfRange("", -1, -1, "string", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsGivenStringShorterThanMinLength()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.LengthOutOfRange("a", 2, 2, "string"));
+    }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenStringShorterThanMinLength()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.LengthOutOfRange("a", 2, 2, "string", exception: customException));
     }
 
     [Fact]
@@ -42,10 +63,25 @@ public class GuardAgainstStringLengthOutOfRange
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenStringLongerThanMaxLength()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.LengthOutOfRange("abcd", 2, 2, "string", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsWhenMinIsBiggerThanMax()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.LengthOutOfRange("asd", 4, 2, "string"));
     }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedWhenMinIsBiggerThanMax()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.LengthOutOfRange("asd", 4, 2, "string", exception: customException));
+    }
+
 
     [Fact]
     public void ReturnsExpectedValueWhenGivenLongerString()

--- a/test/GuardClauses.UnitTests/GuardAgainstStringTooLong.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstStringTooLong.cs
@@ -24,9 +24,24 @@ public class GuardAgainstStringTooLong
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNonPositiveMaxLength()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.StringTooLong("a", 0, "string", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.StringTooLong("a", -1, "string", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsGivenStringLongerThanMaxLength()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.StringTooLong("abc", 2, "string"));
+    }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenStringLongerThanMaxLength()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.StringTooLong("abc", 2, "string", exception: customException));
     }
 
     [Fact]

--- a/test/GuardClauses.UnitTests/GuardAgainstStringTooShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstStringTooShort.cs
@@ -23,6 +23,13 @@ public class GuardAgainstStringTooShort
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenEmptyString()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.StringTooShort("", 1, "string", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsGivenNonPositiveMinLength()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.StringTooShort("", 0, "string"));
@@ -30,10 +37,26 @@ public class GuardAgainstStringTooShort
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenNonPositiveMinLength()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.StringTooShort("", 0, "string", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.StringTooShort("", -1, "string", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsGivenStringShorterThanMinLength()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.StringTooShort("a", 2, "string"));
     }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenStringShorterThanMinLength()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.StringTooShort("a", 2, "string", exception: customException));
+    }
+
 
     [Fact]
     public void ReturnsExpectedValueWhenGivenLongerString()

--- a/test/GuardClauses.UnitTests/GuardAgainstZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstZero.cs
@@ -31,9 +31,23 @@ public class GuardAgainstZero
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueIntZero()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Zero(0, "zero", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsGivenZeroValueLongZero()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0L, "zero"));
+    }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueLongZero()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Zero(0L, "zero", exception: customException));
     }
 
     [Fact]
@@ -43,9 +57,23 @@ public class GuardAgainstZero
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDecimalZero()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Zero(0.0M, "zero", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsGivenZeroValueFloatZero()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0f, "zero"));
+    }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueFloatZero()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Zero(0.0f, "zero", exception: customException));
     }
 
     [Fact]
@@ -54,12 +82,24 @@ public class GuardAgainstZero
         Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0, "zero"));
     }
 
-
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDoubleZero()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Zero(0.0, "zero", exception: customException));
+    }
 
     [Fact]
     public void ThrowsGivenZeroValueDefaultInt()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(int), "zero"));
+    }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDefaultInt()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Zero(default(int), "zero", exception: customException));
     }
 
     [Fact]
@@ -69,9 +109,23 @@ public class GuardAgainstZero
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDefaultLong()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Zero(default(long), "zero", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsGivenZeroValueDefaultDecimal()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(decimal), "zero"));
+    }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDefaultDecimal()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Zero(default(decimal), "zero", exception: customException));
     }
 
     [Fact]
@@ -81,17 +135,38 @@ public class GuardAgainstZero
     }
 
     [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDefaultFloat()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Zero(default(float), "zero", exception: customException));
+    }
+
+    [Fact]
     public void ThrowsGivenZeroValueDefaultDouble()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(double), "zero"));
     }
 
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDefaultDouble()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Zero(default(double), "zero", exception: customException));
+    }
 
     [Fact]
     public void ThrowsGivenZeroValueDecimalDotZero()
     {
         Assert.Throws<ArgumentException>(() => Guard.Against.Zero(decimal.Zero, "zero"));
     }
+
+    [Fact]
+    public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDecimalDotZero()
+    {
+        Exception customException = new Exception();
+        Assert.Throws<Exception>(() => Guard.Against.Zero(decimal.Zero, "zero", exception: customException));
+    }
+
 
     [Fact]
     public void ReturnsExpectedValueWhenGivenNonZeroValue()


### PR DESCRIPTION
This new optional parameter can be supplied to the IGuardClause methods to throw the supplied exception instead of the default one in the method.

it's usage would be something like this:
```
var emplyeeName = null;
Guard.Against.Null(emplyeeName , exception: new EmployeeNameException());
```

the custom exception would only be thrown if exception relates to what the method checks and not thrown for param validation for the method itself

for instance, the custom exception would not be thrown here instead of ArgumentException because that validates the params (rangeFrom and rangeTo) for the method itself

```
    if (rangeFrom.CompareTo(rangeTo) > 0)
    {
        throw new ArgumentException(message ?? $"{nameof(rangeFrom)} should be less or equal than {nameof(rangeTo)}", parameterName);
    }

    if (input.Any(x => x.CompareTo(rangeFrom) < 0 || x.CompareTo(rangeTo) > 0))
    {
        if (string.IsNullOrEmpty(message))
        {
            throw exception ?? new ArgumentOutOfRangeException(parameterName, message ?? $"Input {parameterName} had out of range item(s)");
        }
        throw exception ?? new ArgumentOutOfRangeException(parameterName, message);
    }
```
