### PR TITLE
Use Func to pass custom exception to Guard methods

### DIFF
--- a/src/GuardClauses/GuardAgainstEmptyOrWhiteSpaceExtensions.cs
+++ b/src/GuardClauses/GuardAgainstEmptyOrWhiteSpaceExtensions.cs
@@ -12,7 +12,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception">Optional. Custom exception</param>
+    /// <param name="exceptionCreator">Optional. Custom exception</param>
     /// <returns><paramref name="input" /> if the value is not an empty string.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -21,10 +21,12 @@ public static partial class GuardClauseExtensions
         ReadOnlySpan<char> input,
         string parameterName,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
         if (input.Length == 0 || input == string.Empty)
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName);
         }
         return input;
@@ -37,17 +39,19 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception">Optional. Custom exception</param>
+    /// <param name="exceptionCreator">Optional. Custom exception</param>
     /// <returns><paramref name="input" /> if the value is not an empty or whitespace string.</returns>
     /// <exception cref="ArgumentException"></exception>
     public static ReadOnlySpan<char> WhiteSpace(this IGuardClause guardClause,
         ReadOnlySpan<char> input,
         string parameterName,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
         if (MemoryExtensions.IsWhiteSpace(input))
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} was empty.", parameterName!);
         }
 

--- a/src/GuardClauses/GuardAgainstExpressionExtensions.cs
+++ b/src/GuardClauses/GuardAgainstExpressionExtensions.cs
@@ -17,7 +17,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input">The input to evaluate.</param>
     /// <param name="message">The message to include in the exception if the input is invalid.</param>
     /// <param name="parameterName">The name of the parameter to include in the thrown exception, captured automatically from the input expression.</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns>The <paramref name="input"/> if the <paramref name="func"/> evaluates to false, indicating a valid state.</returns>
     /// <exception cref="ArgumentException">Thrown when the validation function returns true, indicating that the input is invalid.</exception>
     /// <exception cref="Exception"></exception>
@@ -26,11 +26,13 @@ public static partial class GuardClauseExtensions
         T input,
         string message,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
         where T : struct
     {
         if (func(input))
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new ArgumentException(message, parameterName!);
         }
 
@@ -48,7 +50,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input">The input to evaluate.</param>
     /// <param name="message">The message to include in the exception if the input is invalid.</param>
     /// <param name="parameterName">The name of the parameter to include in the thrown exception, captured automatically from the input expression.</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input"/> if the <paramref name="func"/> evaluates to true </returns>
     /// <exception cref="ArgumentException">Thrown when the validation function returns true, indicating that the input is invalid.</exception>
     /// <exception cref="Exception"></exception>
@@ -57,11 +59,13 @@ public static partial class GuardClauseExtensions
         T input,
         string message,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
         where T : struct
     {
         if (await func(input))
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new ArgumentException(message, parameterName!);
         }
 

--- a/src/GuardClauses/GuardAgainstInvalidFormatExtensions.cs
+++ b/src/GuardClauses/GuardAgainstInvalidFormatExtensions.cs
@@ -14,7 +14,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="regexPattern"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -23,11 +23,13 @@ public static partial class GuardClauseExtensions
         string parameterName,
         string regexPattern,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator =  null)
     {
         var m = Regex.Match(input, regexPattern);
         if (!m.Success || input != m.Value)
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new ArgumentException(message ?? $"Input {parameterName} was not in required format", parameterName);
         }
 
@@ -42,7 +44,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="predicate"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
@@ -51,10 +53,12 @@ public static partial class GuardClauseExtensions
         T input, string parameterName, 
         Func<T, bool> predicate, 
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator =  null)
     {
         if (!predicate(input))
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new ArgumentException(message ?? $"Input {parameterName} did not satisfy the options", parameterName);
         }
 
@@ -69,7 +73,7 @@ public static partial class GuardClauseExtensions
     /// <param name="parameterName"></param>
     /// <param name="predicate"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
@@ -79,10 +83,12 @@ public static partial class GuardClauseExtensions
         string parameterName,
         Func<T, Task<bool>> predicate,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator =  null)
     {
         if (!await predicate(input))
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new ArgumentException(message ?? $"Input {parameterName} did not satisfy the options", parameterName);
         }
 

--- a/src/GuardClauses/GuardAgainstNegativeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNegativeExtensions.cs
@@ -12,7 +12,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -20,9 +20,9 @@ public static partial class GuardClauseExtensions
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
-        return Negative<int>(guardClause, input, parameterName, message, exception);
+        return Negative<int>(guardClause, input, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -32,7 +32,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -40,9 +40,9 @@ public static partial class GuardClauseExtensions
         long input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
-        return Negative<long>(guardClause, input, parameterName, message, exception);
+        return Negative<long>(guardClause, input, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -52,16 +52,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="Exception"></exception>
     public static decimal Negative(this IGuardClause guardClause,
         decimal input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null, 
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
-        return Negative<decimal>(guardClause, input, parameterName, message, exception);
+        return Negative<decimal>(guardClause, input, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -71,15 +71,15 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="Exception"></exception>
     public static float Negative(this IGuardClause guardClause,
         float input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? exception = null)
+        string? message = null, Func<Exception>? exceptionCreator = null)
     {
-        return Negative<float>(guardClause, input, parameterName, message, exception);
+        return Negative<float>(guardClause, input, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -89,15 +89,15 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="Exception"></exception>
     public static double Negative(this IGuardClause guardClause,
         double input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? exception = null)
+        string? message = null, Func<Exception>? exceptionCreator = null)
     {
-        return Negative<double>(guardClause, input, parameterName, message, exception);
+        return Negative<double>(guardClause, input, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -107,15 +107,15 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="Exception"></exception>
     public static TimeSpan Negative(this IGuardClause guardClause,
         TimeSpan input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? exception = null)
+        string? message = null, Func<Exception>? exceptionCreator = null)
     {
-        return Negative<TimeSpan>(guardClause, input, parameterName, message, exception);
+        return Negative<TimeSpan>(guardClause, input, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -125,17 +125,19 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     private static T Negative<T>(this IGuardClause guardClause,
         T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? exception = null) where T : struct, IComparable
+        string? message = null, Func<Exception>? exceptionCreator = null) where T : struct, IComparable
     {
         if (input.CompareTo(default(T)) < 0)
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} cannot be negative.", parameterName!);
         }
 
@@ -149,16 +151,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static int NegativeOrZero(this IGuardClause guardClause,
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? exception = null)
+        string? message = null, Func<Exception>? exceptionCreator = null)
     {
-        return NegativeOrZero<int>(guardClause, input, parameterName, message, exception);
+        return NegativeOrZero<int>(guardClause, input, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -168,16 +170,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static long NegativeOrZero(this IGuardClause guardClause,
         long input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? exception = null)
+        string? message = null, Func<Exception>? exceptionCreator = null)
     {
-        return NegativeOrZero<long>(guardClause, input, parameterName, message, exception);
+        return NegativeOrZero<long>(guardClause, input, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -187,16 +189,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static decimal NegativeOrZero(this IGuardClause guardClause,
         decimal input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? exception = null)
+        string? message = null, Func<Exception>? exceptionCreator = null)
     {
-        return NegativeOrZero<decimal>(guardClause, input, parameterName, message, exception);
+        return NegativeOrZero<decimal>(guardClause, input, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -206,16 +208,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static float NegativeOrZero(this IGuardClause guardClause,
         float input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? exception = null)
+        string? message = null, Func<Exception>? exceptionCreator = null)
     {
-        return NegativeOrZero<float>(guardClause, input, parameterName, message, exception);
+        return NegativeOrZero<float>(guardClause, input, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -225,16 +227,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static double NegativeOrZero(this IGuardClause guardClause,
         double input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? exception = null)
+        string? message = null, Func<Exception>? exceptionCreator = null)
     {
-        return NegativeOrZero<double>(guardClause, input, parameterName, message, exception);
+        return NegativeOrZero<double>(guardClause, input, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -244,16 +246,16 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static TimeSpan NegativeOrZero(this IGuardClause guardClause,
         TimeSpan input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? exception = null)
+        string? message = null, Func<Exception>? exceptionCreator = null)
     {
-        return NegativeOrZero<TimeSpan>(guardClause, input, parameterName, message, exception);
+        return NegativeOrZero<TimeSpan>(guardClause, input, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -264,7 +266,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative or zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -272,10 +274,12 @@ public static partial class GuardClauseExtensions
         T input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null, 
-        Exception? exception = null) where T : struct, IComparable
+        Func<Exception>? exceptionCreator = null) where T : struct, IComparable
     {
         if (input.CompareTo(default(T)) <= 0)
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} cannot be zero or negative.", parameterName!);
         }
 

--- a/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNotFoundExtensions.cs
@@ -14,7 +14,7 @@ public static partial class GuardClauseExtensions
     /// <param name="key"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
     /// <exception cref="NotFoundException"></exception>
     /// <exception cref="Exception"></exception>
@@ -22,12 +22,14 @@ public static partial class GuardClauseExtensions
         [NotNull][ValidatedNotNull] string key,
         [NotNull][ValidatedNotNull] T? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator =  null)
     {
         guardClause.NullOrEmpty(key, nameof(key));
 
         if (input is null)
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new NotFoundException(key, parameterName!);
         }
 
@@ -43,7 +45,7 @@ public static partial class GuardClauseExtensions
     /// <param name="key"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not null.</returns>
     /// <exception cref="NotFoundException"></exception>
     /// <exception cref="Exception"></exception>
@@ -51,12 +53,14 @@ public static partial class GuardClauseExtensions
         [NotNull][ValidatedNotNull] TKey key,
         [NotNull][ValidatedNotNull]T? input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        Exception? exception = null) where TKey : struct
+        Func<Exception>? exceptionCreator =  null) where TKey : struct
     {
         guardClause.Null(key, nameof(key));
 
         if (input is null)
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             // TODO: Can we safely consider that ToString() won't return null for struct?
             throw exception ?? new NotFoundException(key.ToString()!, parameterName!);
         }

--- a/src/GuardClauses/GuardAgainstNullExtensions.cs
+++ b/src/GuardClauses/GuardAgainstNullExtensions.cs
@@ -248,6 +248,6 @@ public static partial class GuardClauseExtensions
     {
         Guard.Against.Null(input, parameterName, message, exceptionCreator: exceptionCreator);
 
-        return Guard.Against.InvalidInput(input, parameterName, predicate, message, exceptionCreator?.Invoke());
+        return Guard.Against.InvalidInput(input, parameterName, predicate, message, exceptionCreator);
     }
 }

--- a/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
+++ b/src/GuardClauses/GuardAgainstOutOfRangeExtensions.cs
@@ -31,9 +31,9 @@ public static partial class GuardClauseExtensions
         Func<Exception>? exceptionCreator = null)
     {
         Guard.Against.Negative<int>(maxLength - minLength, parameterName: "min or max length",
-            message: "Min length must be equal or less than max length.", exception: exceptionCreator?.Invoke());
-        Guard.Against.StringTooShort(input, minLength, nameof(minLength), exception: exceptionCreator?.Invoke());
-        Guard.Against.StringTooLong(input, maxLength, nameof(maxLength), exception: exceptionCreator?.Invoke());
+            message: "Min length must be equal or less than max length.", exceptionCreator: exceptionCreator);
+        Guard.Against.StringTooShort(input, minLength, nameof(minLength), exceptionCreator: exceptionCreator);
+        Guard.Against.StringTooLong(input, maxLength, nameof(maxLength), exceptionCreator: exceptionCreator);
 
         return input;
     }
@@ -149,7 +149,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
@@ -157,10 +157,10 @@ public static partial class GuardClauseExtensions
     public static DateTime NullOrOutOfSQLDateRange(this IGuardClause guardClause,
          [NotNull][ValidatedNotNull] DateTime? input,
          [CallerArgumentExpression("input")] string? parameterName = null,
-         string? message = null, Exception? exception = null)
+         string? message = null, Func<Exception>? exceptionCreator = null)
     {
-        guardClause.Null(input, nameof(input), exceptionCreator: () =>exception);
-        return OutOfSQLDateRange(guardClause, input.Value, parameterName, message, exception);
+        guardClause.Null(input, nameof(input), exceptionCreator: exceptionCreator);
+        return OutOfSQLDateRange(guardClause, input.Value, parameterName, message, exceptionCreator);
     }
 
     /// <summary>
@@ -170,20 +170,20 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is in the range of valid SqlDateTime values.</returns>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     /// <exception cref="Exception"></exception>
     public static DateTime OutOfSQLDateRange(this IGuardClause guardClause,
         DateTime input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        string? message = null, Exception? exception = null)
+        string? message = null, Func<Exception>? exceptionCreator = null)
     {
         // System.Data is unavailable in .NET Standard so we can't use SqlDateTime.
         const long sqlMinDateTicks = 552877920000000000;
         const long sqlMaxDateTicks = 3155378975999970000;
 
-        return NullOrOutOfRangeInternal<DateTime>(guardClause, input, parameterName, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks), message,exception);
+        return NullOrOutOfRangeInternal<DateTime>(guardClause, input, parameterName, new DateTime(sqlMinDateTicks), new DateTime(sqlMaxDateTicks), message, exceptionCreator);
     }
 
     /// <summary>
@@ -195,7 +195,7 @@ public static partial class GuardClauseExtensions
     /// <param name="rangeFrom"></param>
     /// <param name="rangeTo"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not out of range.</returns>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     /// <exception cref="Exception"></exception>
@@ -204,9 +204,9 @@ public static partial class GuardClauseExtensions
         string parameterName,
         [NotNull][ValidatedNotNull] T rangeFrom,
         [NotNull][ValidatedNotNull] T rangeTo,
-        string? message = null, Exception? exception = null) where T : IComparable, IComparable<T>
+        string? message = null, Func<Exception>? exceptionCreator = null) where T : IComparable, IComparable<T>
     {
-        return NullOrOutOfRangeInternal<T>(guardClause, input, parameterName, rangeFrom, rangeTo, message,exception);
+        return NullOrOutOfRangeInternal<T>(guardClause, input, parameterName, rangeFrom, rangeTo, message, exceptionCreator);
     }
 
 
@@ -220,7 +220,7 @@ public static partial class GuardClauseExtensions
     /// <param name="rangeFrom"></param>
     /// <param name="rangeTo"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not not null or out of range.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
@@ -231,10 +231,10 @@ public static partial class GuardClauseExtensions
         string parameterName,
         [NotNull][ValidatedNotNull] T rangeFrom,
         [NotNull][ValidatedNotNull] T rangeTo,
-        string? message = null, Exception? exception = null) where T : IComparable<T>
+        string? message = null, Func<Exception>? exceptionCreator = null) where T : IComparable<T>
     {
-        guardClause.Null(input, nameof(input),exceptionCreator: () => exception);
-        return NullOrOutOfRangeInternal(guardClause, input, parameterName, rangeFrom, rangeTo, message, exception);
+        guardClause.Null(input, nameof(input),exceptionCreator: exceptionCreator);
+        return NullOrOutOfRangeInternal(guardClause, input, parameterName, rangeFrom, rangeTo, message, exceptionCreator);
     }
 
     /// <summary>
@@ -247,7 +247,7 @@ public static partial class GuardClauseExtensions
     /// <param name="rangeFrom"></param>
     /// <param name="rangeTo"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not not null or out of range.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
@@ -258,10 +258,10 @@ public static partial class GuardClauseExtensions
         string parameterName,
         [NotNull][ValidatedNotNull] T rangeFrom,
         [NotNull][ValidatedNotNull] T rangeTo,
-        string? message = null, Exception? exception = null) where T : struct, IComparable<T>
+        string? message = null, Func<Exception>? exceptionCreator = null) where T : struct, IComparable<T>
     {
-        guardClause.Null(input, nameof(input), exceptionCreator: () => exception);
-        return NullOrOutOfRangeInternal<T>(guardClause, input.Value, parameterName, rangeFrom, rangeTo, message, exception);
+        guardClause.Null(input, nameof(input), exceptionCreator: exceptionCreator);
+        return NullOrOutOfRangeInternal<T>(guardClause, input.Value, parameterName, rangeFrom, rangeTo, message, exceptionCreator);
     }
 
     /// <exception cref="ArgumentNullException"></exception>
@@ -273,7 +273,7 @@ public static partial class GuardClauseExtensions
         [NotNull][ValidatedNotNull] T? rangeFrom,
         [NotNull][ValidatedNotNull] T? rangeTo,
         string? message = null,
-        Exception? exception = null) where T : IComparable<T>?
+        Func<Exception>? exceptionCreator = null) where T : IComparable<T>?
     {
         Guard.Against.Null(input, nameof(input));
         Guard.Against.Null(parameterName, nameof(parameterName));
@@ -287,6 +287,8 @@ public static partial class GuardClauseExtensions
 
         if (input.CompareTo(rangeFrom) < 0 || input.CompareTo(rangeTo) > 0)
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             if (string.IsNullOrEmpty(message))
             {
                 throw exception ?? new ArgumentOutOfRangeException(parameterName, $"Input {parameterName} was out of range");

--- a/src/GuardClauses/GuardAgainstStringLengthExtensions.cs
+++ b/src/GuardClauses/GuardAgainstStringLengthExtensions.cs
@@ -17,7 +17,7 @@ public static partial class GuardClauseExtensions
     /// <param name="minLength"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -26,11 +26,13 @@ public static partial class GuardClauseExtensions
         int minLength,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
-        Guard.Against.NegativeOrZero(minLength, nameof(minLength), exception: exception);
+        Guard.Against.NegativeOrZero(minLength, nameof(minLength), exceptionCreator: exceptionCreator);
         if (input.Length < minLength)
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too short. Minimum length is {minLength}.", parameterName);
         }
         return input;
@@ -44,7 +46,7 @@ public static partial class GuardClauseExtensions
     /// <param name="maxLength"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not negative.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -53,11 +55,13 @@ public static partial class GuardClauseExtensions
         int maxLength,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
-        Guard.Against.NegativeOrZero(maxLength, nameof(maxLength), exception: exception);
+        Guard.Against.NegativeOrZero(maxLength, nameof(maxLength), exceptionCreator: exceptionCreator);
         if (input.Length > maxLength)
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new ArgumentException(message ?? $"Input {parameterName} with length {input.Length} is too long. Maximum length is {maxLength}.", parameterName);
         }
         return input;

--- a/src/GuardClauses/GuardAgainstZeroExtensions.cs
+++ b/src/GuardClauses/GuardAgainstZeroExtensions.cs
@@ -13,7 +13,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -21,9 +21,9 @@ public static partial class GuardClauseExtensions
         int input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
-        return Zero<int>(guardClause, input, parameterName!, message, exception);
+        return Zero<int>(guardClause, input, parameterName!, message, exceptionCreator);
     }
 
     /// <summary>
@@ -33,7 +33,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -41,9 +41,9 @@ public static partial class GuardClauseExtensions
         long input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
-        return Zero<long>(guardClause, input, parameterName!, message, exception);
+        return Zero<long>(guardClause, input, parameterName!, message, exceptionCreator);
     }
 
     /// <summary>
@@ -53,7 +53,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -61,9 +61,9 @@ public static partial class GuardClauseExtensions
         decimal input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
-        return Zero<decimal>(guardClause, input, parameterName!, message,exception);
+        return Zero<decimal>(guardClause, input, parameterName!, message,exceptionCreator);
     }
 
     /// <summary>
@@ -73,7 +73,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -81,9 +81,9 @@ public static partial class GuardClauseExtensions
         float input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
-        return Zero<float>(guardClause, input, parameterName!, message, exception);
+        return Zero<float>(guardClause, input, parameterName!, message, exceptionCreator);
     }
 
     /// <summary>
@@ -93,7 +93,7 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
@@ -101,9 +101,9 @@ public static partial class GuardClauseExtensions
         double input,
         [CallerArgumentExpression("input")] string? parameterName = null,
         string? message = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
-        return Zero<double>(guardClause, input, parameterName!, message,exception);
+        return Zero<double>(guardClause, input, parameterName!, message, exceptionCreator);
     }
 
     /// <summary>
@@ -112,16 +112,16 @@ public static partial class GuardClauseExtensions
     /// <param name="guardClause"></param>
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     public static TimeSpan Zero(this IGuardClause guardClause,
         TimeSpan input,
         [CallerArgumentExpression("input")] string? parameterName = null,
-        Exception? exception = null)
+        Func<Exception>? exceptionCreator = null)
     {
-        return Zero<TimeSpan>(guardClause, input, parameterName!, exception:exception);
+        return Zero<TimeSpan>(guardClause, input, parameterName!, exceptionCreator: exceptionCreator);
     }
 
     /// <summary>
@@ -131,15 +131,17 @@ public static partial class GuardClauseExtensions
     /// <param name="input"></param>
     /// <param name="parameterName"></param>
     /// <param name="message">Optional. Custom error message</param>
-    /// <param name="exception"></param>
+    /// <param name="exceptionCreator"></param>
     /// <returns><paramref name="input" /> if the value is not zero.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="Exception"></exception>
     private static T Zero<T>(this IGuardClause guardClause, T input, string parameterName, string? message = null,
-        Exception? exception = null) where T : struct
+        Func<Exception>? exceptionCreator = null) where T : struct
     {
         if (EqualityComparer<T>.Default.Equals(input, default(T)))
         {
+            Exception? exception = exceptionCreator?.Invoke();
+
             throw exception ?? new ArgumentException(message ?? $"Required input {parameterName} cannot be zero.", parameterName);
         }
 

--- a/test/GuardClauses.UnitTests/GuardAgainstExpression.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstExpression.cs
@@ -34,7 +34,7 @@ public class GuardAgainstExpression
     {
         Exception customException = new Exception();
         int testCase = 10;
-        Assert.Throws<Exception>(() => Guard.Against.Expression((x) => x == 10, testCase, "Value cannot be 10", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Expression((x) => x == 10, testCase, "Value cannot be 10", exceptionCreator: () => customException));
     }
 
 
@@ -57,7 +57,7 @@ public class GuardAgainstExpression
     {
         Exception customException = new Exception();
         double testCase = 1.1;
-        Assert.Throws<Exception>(() => Guard.Against.Expression((x) => x == 1.1, testCase, "Value cannot be 1.1", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Expression((x) => x == 1.1, testCase, "Value cannot be 1.1", exceptionCreator: () => customException));
     }
 
 
@@ -80,7 +80,7 @@ public class GuardAgainstExpression
     public void GivenCustomStructWhenTheExpressionEvaluatesToTrueThrowsCustomExceptionWhenSupplied(CustomStruct test)
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Expression((x) => x.FieldName == "FieldValue", test, "FieldValue is not matching", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Expression((x) => x.FieldName == "FieldValue", test, "FieldValue is not matching", exceptionCreator: () => customException));
     }
 
 

--- a/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
@@ -40,7 +40,7 @@ public class GuardAgainstInvalidFormatTests
     public void ThrowsCustomExceptionWhenSuppliedGivenGivenIncorrectFormat(string input, string regexPattern)
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.InvalidFormat(input, nameof(input), regexPattern, exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.InvalidFormat(input, nameof(input), regexPattern, exceptionCreator: () => customException));
     }
 
 

--- a/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
@@ -39,7 +39,7 @@ public class GuardAgainstNegative
     public void ThrowsCustomExceptionWhenSuppliedGivenNegativeIntValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Negative(-1, "negative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Negative(-1, "negative", exceptionCreator: () => customException));
     }
 
 
@@ -53,7 +53,7 @@ public class GuardAgainstNegative
     public void ThrowsCustomExceptionWhenSuppliedGivenNegativeLongValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Negative(-1L, "negative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Negative(-1L, "negative", exceptionCreator: () => customException));
     }
 
 
@@ -67,7 +67,7 @@ public class GuardAgainstNegative
     public void ThrowsCustomExceptionWhenSuppliedGivenNegativeDecimalValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Negative(-1.0M, "negative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Negative(-1.0M, "negative", exceptionCreator: () => customException));
     }
 
 
@@ -81,7 +81,7 @@ public class GuardAgainstNegative
     public void ThrowsCustomExceptionWhenSuppliedGivenNegativeFloatValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Negative(-1.0f, "negative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Negative(-1.0f, "negative", exceptionCreator: () => customException));
     }
 
 
@@ -95,7 +95,7 @@ public class GuardAgainstNegative
     public void ThrowsCustomExceptionWhenSuppliedGivenNegativeDoubleValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Negative(-1.0, "negative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Negative(-1.0, "negative", exceptionCreator: () => customException));
     }
 
 
@@ -109,7 +109,7 @@ public class GuardAgainstNegative
     public void ThrowsCustomExceptionWhenSuppliedGivenNegativeTimeSpanValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Negative(TimeSpan.FromSeconds(-1), "negative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Negative(TimeSpan.FromSeconds(-1), "negative", exceptionCreator: () => customException));
     }
 
 

--- a/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
@@ -28,7 +28,7 @@ public class GuardAgainstNegativeOrZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroIntValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0, "intZero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0, "intZero", exceptionCreator: () => customException));
     }
 
 
@@ -42,7 +42,7 @@ public class GuardAgainstNegativeOrZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroLongValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0L, "longZero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0L, "longZero", exceptionCreator: () => customException));
     }
 
 
@@ -56,7 +56,7 @@ public class GuardAgainstNegativeOrZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroDecimalValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0M, "decimalZero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0M, "decimalZero", exceptionCreator: () => customException));
     }
 
 
@@ -70,7 +70,7 @@ public class GuardAgainstNegativeOrZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroFloatValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0f, "floatZero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0f, "floatZero", exceptionCreator: () => customException));
     }
 
 
@@ -84,7 +84,7 @@ public class GuardAgainstNegativeOrZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroDoubleValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0.0, "doubleZero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(0.0, "doubleZero", exceptionCreator: () => customException));
     }
 
 
@@ -98,7 +98,7 @@ public class GuardAgainstNegativeOrZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroTimeSpanValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(TimeSpan.Zero, "timespanZero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(TimeSpan.Zero, "timespanZero", exceptionCreator: () => customException));
     }
 
 
@@ -113,8 +113,8 @@ public class GuardAgainstNegativeOrZero
     public void ThrowsCustomExceptionWhenSuppliedGivenNegativeIntValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1, "intNegative", exception: customException));
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-42, "intNegative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1, "intNegative", exceptionCreator: () => customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-42, "intNegative", exceptionCreator: () => customException));
     }
 
 
@@ -129,8 +129,8 @@ public class GuardAgainstNegativeOrZero
     public void ThrowsCustomExceptionWhenSuppliedGivenNegativeLongValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1L, "longNegative", exception: customException));
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-456L, "longNegative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1L, "longNegative", exceptionCreator: () => customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-456L, "longNegative", exceptionCreator: () => customException));
     }
 
 
@@ -145,8 +145,8 @@ public class GuardAgainstNegativeOrZero
     public void ThrowsCustomExceptionWhenSuppliedGivenNegativeDecimalValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1M, "decimalNegative", exception: customException));
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-567M, "decimalNegative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1M, "decimalNegative", exceptionCreator: () => customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-567M, "decimalNegative", exceptionCreator: () => customException));
     }
 
 
@@ -163,8 +163,8 @@ public class GuardAgainstNegativeOrZero
     public void ThrowsCustomExceptionWhenSuppliedGivenNegativeFloatValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1f, "floatNegative", exception: customException));
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-4567f, "floatNegative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1f, "floatNegative", exceptionCreator: () => customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-4567f, "floatNegative", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -179,8 +179,8 @@ public class GuardAgainstNegativeOrZero
     public void ThrowsCustomExceptionWhenSuppliedGivenNegativeDoubleValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1.0, "doubleNegative", exception: customException));
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-456.453, "doubleNegative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-1.0, "doubleNegative", exceptionCreator: () => customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(-456.453, "doubleNegative", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -194,8 +194,8 @@ public class GuardAgainstNegativeOrZero
     public void ThrowsCustomExceptionWhenSuppliedGivenNegativeTimeSpanValue()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(-1), "timespanNegative", exception: customException));
-        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(-456), "timespanNegative", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(-1), "timespanNegative", exceptionCreator: () => customException));
+        Assert.Throws<Exception>(() => Guard.Against.NegativeOrZero(TimeSpan.FromSeconds(-456), "timespanNegative", exceptionCreator: () => customException));
     }
 
     [Fact]

--- a/test/GuardClauses.UnitTests/GuardAgainstNotFound.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNotFound.cs
@@ -28,7 +28,7 @@ public class GuardAgainstNotFound
     {
         object obj = null!;
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.NotFound(1, obj, "null", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.NotFound(1, obj, "null", exceptionCreator: () => customException));
     }
 
     [Fact]

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
@@ -59,7 +59,7 @@ public class GuardAgainstNullOrEmpty
     public void ThrowsCustomExceptionWhenSuppliedGivenEmptyStringSpan()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Empty("".AsSpan(), "emptyStringSpan", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Empty("".AsSpan(), "emptyStringSpan", exceptionCreator: () => customException));
     }
 
     [Fact]

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfRangeForClassIComparable.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfRangeForClassIComparable.cs
@@ -54,9 +54,9 @@ namespace GuardClauses.UnitTests
         public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue()
         {
             Exception customException = new Exception();
-            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(new TestObj(-1), "index", new TestObj(1), new TestObj(3), exception: customException));
-            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(new TestObj(0), "index", new TestObj(1), new TestObj(3), exception: customException));
-            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(new TestObj(4), "index", new TestObj(1), new TestObj(3), exception: customException));
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(new TestObj(-1), "index", new TestObj(1), new TestObj(3), exceptionCreator: () => customException));
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(new TestObj(0), "index", new TestObj(1), new TestObj(3), exceptionCreator: () => customException));
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(new TestObj(4), "index", new TestObj(1), new TestObj(3), exceptionCreator: () => customException));
         }
 
         [Fact]

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfRangeForInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfRangeForInt.cs
@@ -32,7 +32,7 @@ namespace GuardClauses.UnitTests
         public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(int input, int rangeFrom, int rangeTo)
         {
             Exception customException = new Exception();
-            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(input, "index", rangeFrom, rangeTo, exceptionCreator: () => customException));
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfRangeForNullableInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfRangeForNullableInt.cs
@@ -32,7 +32,7 @@ namespace GuardClauses.UnitTests
         public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(int? input, int rangeFrom, int rangeTo)
         {
             Exception customException = new Exception();
-            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(input, "index", rangeFrom, rangeTo, exceptionCreator: () => customException));
         }
 
         [Theory]
@@ -65,7 +65,7 @@ namespace GuardClauses.UnitTests
         public void ThrowsCustomExceptionWhenSuppliedGivenInvalidNullArgumentValue()
         {
             Exception customException = new Exception();
-            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(null, "index", -10, 10, exception: customException));
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfRange(null, "index", -10, 10, exceptionCreator: () => customException));
         }
 
     }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfSQLDateRange.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrOutOfSQLDateRange.cs
@@ -34,7 +34,7 @@ namespace GuardClauses.UnitTests
             DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-offsetInSeconds);
             Exception customException = new Exception();
 
-            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfSQLDateRange(date, nameof(date), exception: customException));
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfSQLDateRange(date, nameof(date), exceptionCreator: () => customException));
         }
 
 
@@ -106,7 +106,7 @@ namespace GuardClauses.UnitTests
         public void ThrowsCustomExceptionWhenSuppliedGivenInvalidNullArgumentValue()
         {
             Exception customException = new Exception();
-            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfSQLDateRange(null, "index", exception: customException));
+            Assert.Throws<Exception>(() => Guard.Against.NullOrOutOfSQLDateRange(null, "index", exceptionCreator: () => customException));
         }
         public static IEnumerable<object[]> GetSqlDateTimeTestVectors()
         {

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -57,7 +57,7 @@ public class GuardAgainstNullOrWhiteSpace
     public void ThrowsCustomExceptionWhenSuppliedGivenEmptyStringSpan()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.WhiteSpace("".AsSpan(), "emptyStringSpan", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.WhiteSpace("".AsSpan(), "emptyStringSpan", exceptionCreator: () => customException));
     }
 
     [Theory]
@@ -78,7 +78,7 @@ public class GuardAgainstNullOrWhiteSpace
         Assert.Throws<Exception>(() => Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring", 
             exceptionCreator: () => customException));
         Assert.Throws<Exception>(() => Guard.Against.WhiteSpace(whiteSpaceString.AsSpan(), "whiteSpaceStringSpan", 
-            exception: customException));
+            exceptionCreator: () => customException));
     }
 
 

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDateTime.cs
@@ -38,7 +38,7 @@ public class GuardAgainstOutOfRangeForDateTime
         DateTime rangeFrom = input.AddSeconds(rangeFromOffset);
         DateTime rangeTo = input.AddSeconds(rangeToOffset);
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exceptionCreator: () => customException));
     }
 
     [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
@@ -31,7 +31,7 @@ public class GuardAgainstOutOfRangeForDecimal
     public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(decimal input, decimal rangeFrom, decimal rangeTo)
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exceptionCreator: () => customException));
     }
 
     [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
@@ -31,7 +31,7 @@ public class GuardAgainstOutOfRangeForDouble
     public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(double input, double rangeFrom, double rangeTo)
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exceptionCreator: () => customException));
     }
 
     [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
@@ -32,7 +32,7 @@ public class GuardAgainstOutOfRangeForFloat
     public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(float input, float rangeFrom, float rangeTo)
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exceptionCreator: () => customException));
     }
 
     [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
@@ -32,7 +32,7 @@ public class GuardAgainstOutOfRangeForInt
     public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(int input, int rangeFrom, int rangeTo)
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exceptionCreator: () => customException));
     }
 
     [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInvalidInput.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInvalidInput.cs
@@ -36,7 +36,7 @@ public class GuardAgainstOutOfRangeForInvalidInput
     public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue<T>(T input, Func<T, bool> func)
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.InvalidInput(input, nameof(input), func, exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.InvalidInput(input, nameof(input), func, exceptionCreator: () => customException));
     }
 
     [Theory]
@@ -51,7 +51,7 @@ public class GuardAgainstOutOfRangeForInvalidInput
     public async Task ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValueAsync<T>(T input, Func<T, Task<bool>> func)
     {
         Exception customException = new Exception();
-        await Assert.ThrowsAsync<Exception>(async () => await Guard.Against.InvalidInputAsync(input, nameof(input), func, exception: customException));
+        await Assert.ThrowsAsync<Exception>(async () => await Guard.Against.InvalidInputAsync(input, nameof(input), func, exceptionCreator: () => customException));
     }
 
 

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
@@ -31,7 +31,7 @@ public class GuardAgainstOutOfRangeForShort
     public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(short input, short rangeFrom, short rangeTo)
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exceptionCreator: () => customException));
     }
 
     [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForStructIComparable.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForStructIComparable.cs
@@ -36,7 +36,7 @@ public class GuardAgainstOutOfRangeForStructIComparable
     public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(int input1, int input2, int rangeFrom1, int rangeFrom2, int rangeTo1, int rangeTo2)
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.OutOfRange((input1, input2), "tuple", (rangeFrom1, rangeFrom2), (rangeTo1, rangeTo2), exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange((input1, input2), "tuple", (rangeFrom1, rangeFrom2), (rangeTo1, rangeTo2), exceptionCreator: () => customException));
     }
 
     [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForTimeSpan.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForTimeSpan.cs
@@ -44,7 +44,7 @@ public class GuardAgainstOutOfRangeForTimeSpan
         var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
         Exception customException = new Exception();
 
-        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan, exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan, exceptionCreator: () => customException));
     }
 
     [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForUint.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForUint.cs
@@ -30,7 +30,7 @@ public class GuardAgainstOutOfRangeForUint
     public void ThrowsCustomExceptionWhenSuppliedGivenOutOfRangeValue(uint input, uint rangeFrom, uint rangeTo)
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, exceptionCreator: () => customException));
     }
 
     [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
@@ -34,7 +34,7 @@ public class GuardAgainstOutOfSQLDateRange
         DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-offsetInSeconds);
         Exception customException = new Exception();
 
-        Assert.Throws<Exception>(() => Guard.Against.OutOfSQLDateRange(date, nameof(date), exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.OutOfSQLDateRange(date, nameof(date), exceptionCreator: () => customException));
     }
 
     [Fact]

--- a/test/GuardClauses.UnitTests/GuardAgainstStringTooLong.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstStringTooLong.cs
@@ -27,8 +27,8 @@ public class GuardAgainstStringTooLong
     public void ThrowsCustomExceptionWhenSuppliedGivenNonPositiveMaxLength()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.StringTooLong("a", 0, "string", exception: customException));
-        Assert.Throws<Exception>(() => Guard.Against.StringTooLong("a", -1, "string", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.StringTooLong("a", 0, "string", exceptionCreator: () => customException));
+        Assert.Throws<Exception>(() => Guard.Against.StringTooLong("a", -1, "string", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -41,7 +41,7 @@ public class GuardAgainstStringTooLong
     public void ThrowsCustomExceptionWhenSuppliedGivenStringLongerThanMaxLength()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.StringTooLong("abc", 2, "string", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.StringTooLong("abc", 2, "string", exceptionCreator: () => customException));
     }
 
     [Fact]

--- a/test/GuardClauses.UnitTests/GuardAgainstStringTooShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstStringTooShort.cs
@@ -26,7 +26,7 @@ public class GuardAgainstStringTooShort
     public void ThrowsCustomExceptionWhenSuppliedGivenEmptyString()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.StringTooShort("", 1, "string", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.StringTooShort("", 1, "string", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -40,8 +40,8 @@ public class GuardAgainstStringTooShort
     public void ThrowsCustomExceptionWhenSuppliedGivenNonPositiveMinLength()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.StringTooShort("", 0, "string", exception: customException));
-        Assert.Throws<Exception>(() => Guard.Against.StringTooShort("", -1, "string", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.StringTooShort("", 0, "string", exceptionCreator: () => customException));
+        Assert.Throws<Exception>(() => Guard.Against.StringTooShort("", -1, "string", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class GuardAgainstStringTooShort
     public void ThrowsCustomExceptionWhenSuppliedGivenStringShorterThanMinLength()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.StringTooShort("a", 2, "string", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.StringTooShort("a", 2, "string", exceptionCreator: () => customException));
     }
 
 

--- a/test/GuardClauses.UnitTests/GuardAgainstZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstZero.cs
@@ -34,7 +34,7 @@ public class GuardAgainstZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueIntZero()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Zero(0, "zero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Zero(0, "zero", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class GuardAgainstZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueLongZero()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Zero(0L, "zero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Zero(0L, "zero", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public class GuardAgainstZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDecimalZero()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Zero(0.0M, "zero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Zero(0.0M, "zero", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class GuardAgainstZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueFloatZero()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Zero(0.0f, "zero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Zero(0.0f, "zero", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public class GuardAgainstZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDoubleZero()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Zero(0.0, "zero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Zero(0.0, "zero", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public class GuardAgainstZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDefaultInt()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Zero(default(int), "zero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Zero(default(int), "zero", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -112,7 +112,7 @@ public class GuardAgainstZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDefaultLong()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Zero(default(long), "zero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Zero(default(long), "zero", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public class GuardAgainstZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDefaultDecimal()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Zero(default(decimal), "zero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Zero(default(decimal), "zero", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -138,7 +138,7 @@ public class GuardAgainstZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDefaultFloat()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Zero(default(float), "zero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Zero(default(float), "zero", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public class GuardAgainstZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDefaultDouble()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Zero(default(double), "zero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Zero(default(double), "zero", exceptionCreator: () => customException));
     }
 
     [Fact]
@@ -164,7 +164,7 @@ public class GuardAgainstZero
     public void ThrowsCustomExceptionWhenSuppliedGivenZeroValueDecimalDotZero()
     {
         Exception customException = new Exception();
-        Assert.Throws<Exception>(() => Guard.Against.Zero(decimal.Zero, "zero", exception: customException));
+        Assert.Throws<Exception>(() => Guard.Against.Zero(decimal.Zero, "zero", exceptionCreator: () => customException));
     }
 
 


### PR DESCRIPTION
It changes the optional exception to a factory using Func.

From

`Guard.Against.Empty(anEmptyString, exception: new SomethingWrongHappenedException());`

To

`Guard.Against.Empty(anEmptyString, exceptionCreator: () => SomethingWrongHappenedException());`

It follows the same approach from https://github.com/ardalis/GuardClauses/commit/6186c68df5af66c7f92841ddbb1e457bb25266c5 in all other methods.

Relates to: #344