### PR TITLE
Set package license explicitly in GuardClauses.csproj with <PackageLicenseExpression>

### DIFF
--- a/src/GuardClauses/GuardClauses.csproj
+++ b/src/GuardClauses/GuardClauses.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
     </PropertyGroup>
-    <ItemGroup>
-        <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
-    </ItemGroup>
     <PropertyGroup>
         <TargetFrameworks>net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <PackageId>Ardalis.GuardClauses</PackageId>


### PR DESCRIPTION
Set the package license to MIT explicitly in the csproj file instead of including a license file. 

With this, the license will show up directly in the about section on the nuget's page on nuget.org like this:
![grafik](https://github.com/user-attachments/assets/f15759db-f81e-466e-8488-5632a27c4198)

instead of just showing a file link like currently:
![grafik](https://github.com/user-attachments/assets/e6290918-a9f3-4fba-ae99-700e81945075)


Additionally, the license is discoverable for tools like [nuget-license](https://github.com/sensslen/nuget-license) to validate licenses of dependencies in a project.